### PR TITLE
Add Svelte i18n framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Works out of the box with:
 | **easy_localization** | `'key'.tr()` `tr('key')` `context.tr('key')` |
 | **flutter_i18n** | `FlutterI18n.translate(context, 'key')` `I18nText('key')` |
 | **GetX** | `'key'.tr` `'key'.trParams({})` |
+| **svelte-i18n** | `$_("key")` `$t("key")` `$format("key")` |
+| **sveltekit-i18n** | `$t("key")` `t("key")` |
 | **Custom** | Configure your own patterns! |
 
 ## 🧩 Supported Languages
@@ -124,6 +126,7 @@ Works out of the box with:
 - Blade
 - Dart (Flutter)
 - Vue.js
+- Svelte
 
 ## ⚙️ Configuration
 

--- a/crates/intl-lens-extension/extension.toml
+++ b/crates/intl-lens-extension/extension.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/nguyenphutrong/intl-lens"
 
 [language_servers.intl-lens]
 name = "Intl Lens Language Server"
-languages = ["TypeScript", "TSX", "JavaScript", "JSX", "HTML", "Angular", "PHP", "Blade", "Vue.js"]
+languages = ["TypeScript", "TSX", "JavaScript", "JSX", "HTML", "Angular", "PHP", "Blade", "Vue.js", "Svelte"]
 
 [language_servers.intl-lens.language_ids]
 "TypeScript" = "typescript"
@@ -21,3 +21,4 @@ languages = ["TypeScript", "TSX", "JavaScript", "JSX", "HTML", "Angular", "PHP",
 "PHP" = "php"
 "Blade" = "blade"
 "Vue.js" = "vue"
+"Svelte" = "svelte"

--- a/crates/intl-lens/src/backend.rs
+++ b/crates/intl-lens/src/backend.rs
@@ -143,6 +143,11 @@ impl I18nBackend {
                 scheme: None,
                 pattern: None,
             },
+            DocumentFilter {
+                language: Some("svelte".to_string()),
+                scheme: None,
+                pattern: None,
+            },
         ]);
 
         let register_options = InlayHintRegistrationOptions {

--- a/crates/intl-lens/src/document.rs
+++ b/crates/intl-lens/src/document.rs
@@ -34,6 +34,10 @@ impl DocumentStore {
     pub fn get(&self, uri: &str) -> Option<&Document> {
         self.documents.get(uri)
     }
+
+    pub fn uris(&self) -> Vec<String> {
+        self.documents.keys().cloned().collect()
+    }
 }
 
 impl Default for DocumentStore {


### PR DESCRIPTION
Support svelte-i18n and sveltekit-i18n patterns including $_(), $t(), $format(), and t() function calls. Add Svelte language registration, project detection, and locale path auto-discovery.