### PR TITLE
Read Intl Lens config from extension settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Trong Nguyen"]
@@ -32,4 +32,4 @@ globset = "0.4"
 walkdir = "2"
 
 # Zed extension
-zed_extension_api = "0.7"
+zed_extension_api = { path = "../zed/crates/extension_api" }

--- a/README.md
+++ b/README.md
@@ -127,14 +127,51 @@ Works out of the box with:
 
 ## ⚙️ Configuration
 
-Create `.zed/i18n.json` in your project root:
+Configure Intl Lens in `.zed/settings.json` under `extensions.intl-lens`:
 
-```json
+```jsonc
 {
-  "localePaths": ["src/locales", "public/locales"],
-  "sourceLocale": "en"
+  "extensions": {
+    "intl-lens": {
+      "localePaths": ["src/locales", "public/locales"],
+      "sourceLocale": "en"
+    }
+  }
 }
 ```
+
+Intl Lens reads its project overrides from `extensions.intl-lens` in user or project settings.
+The legacy `.zed/i18n.json` file is no longer used.
+If you already have an `.i18n-ally.json` or `i18n-ally.config.json`, Intl Lens will still read it as a base config and then apply `extensions.intl-lens` overrides on top.
+In Zed's Extension Settings UI, `localePaths` and `sourceLocale` can now be configured directly.
+
+User settings example:
+
+```jsonc
+{
+  "extensions": {
+    "intl-lens": {
+      "localePaths": ["src/locales", "public/locales"],
+      "sourceLocale": "en"
+    }
+  }
+}
+```
+
+Project settings example:
+
+```jsonc
+{
+  "extensions": {
+    "intl-lens": {
+      "localePaths": ["apps/admin/src/assets/locales"],
+      "sourceLocale": "vi"
+    }
+  }
+}
+```
+
+Set `sourceLocale` to an empty string or `localePaths` to an empty array to fall through to defaults or values from `.i18n-ally.json`.
 
 <details>
 <summary><strong>📋 All Options</strong></summary>

--- a/crates/intl-lens-extension/Cargo.toml
+++ b/crates/intl-lens-extension/Cargo.toml
@@ -9,4 +9,6 @@ authors.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+serde.workspace = true
+serde_json.workspace = true
 zed_extension_api.workspace = true

--- a/crates/intl-lens-extension/extension.toml
+++ b/crates/intl-lens-extension/extension.toml
@@ -1,6 +1,6 @@
 id = "intl-lens"
 name = "Intl Lens"
-version = "0.1.4"
+version = "0.2.0"
 schema_version = 1
 license = "MIT"
 authors = ["Trong Nguyen"]

--- a/crates/intl-lens-extension/src/lib.rs
+++ b/crates/intl-lens-extension/src/lib.rs
@@ -1,7 +1,31 @@
-use zed_extension_api::{self as zed, LanguageServerId, Result, Worktree};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use zed_extension_api::{
+    self as zed, settings::ExtensionSettings, LanguageServerId, Result, Worktree,
+};
+
+const EXTENSION_ID: &str = "intl-lens";
 
 struct IntlLensExtension {
     cached_binary_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+struct IntlLensSettings {
+    #[serde(rename = "binaryPath")]
+    binary_path: Option<String>,
+    locale_paths: Option<Vec<String>>,
+    source_locale: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IntlLensServerSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    locale_paths: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_locale: Option<String>,
 }
 
 impl zed::Extension for IntlLensExtension {
@@ -9,6 +33,32 @@ impl zed::Extension for IntlLensExtension {
         Self {
             cached_binary_path: None,
         }
+    }
+
+    fn settings_contribution(&mut self) -> Option<zed::ExtensionSettingsContribution> {
+        Some(zed::ExtensionSettingsContribution {
+            settings_schema: json!({
+                "type": "object",
+                "properties": {
+                    "localePaths": {
+                        "type": "array",
+                        "description": "Override the locale file paths used by Intl Lens for this worktree.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "sourceLocale": {
+                        "type": "string",
+                        "description": "Override the source locale used for hover previews, inlay hints, and completions. Leave empty to use the project config."
+                    }
+                },
+                "additionalProperties": false
+            }),
+            default_settings: json!({
+                "localePaths": [],
+                "sourceLocale": ""
+            }),
+        })
     }
 
     fn language_server_command(
@@ -24,23 +74,66 @@ impl zed::Extension for IntlLensExtension {
             env: vec![],
         })
     }
+
+    fn language_server_initialization_options(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        Ok(Some(Self::load_settings(worktree).server_settings_json()))
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        Ok(Some(Self::load_settings(worktree).server_settings_json()))
+    }
 }
 
 impl IntlLensExtension {
+    fn load_settings(worktree: &Worktree) -> IntlLensSettings {
+        match ExtensionSettings::for_worktree(EXTENSION_ID, worktree) {
+            Ok(settings) => settings,
+            Err(err) => {
+                eprintln!("Failed to load Intl Lens settings for {EXTENSION_ID}: {err}");
+                IntlLensSettings::default()
+            }
+        }
+    }
+
     fn get_server_binary_path(
         &mut self,
         language_server_id: &LanguageServerId,
         worktree: &Worktree,
     ) -> Result<String> {
-        if let Some(path) = &self.cached_binary_path {
-            if std::fs::metadata(path).is_ok() {
-                return Ok(path.clone());
+        let settings = Self::load_settings(worktree);
+
+        if let Some(path) = settings.normalized_binary_path() {
+            if std::fs::metadata(&path).is_ok() {
+                return Ok(path);
             }
+
+            if let Some(resolved_path) = worktree.which(&path) {
+                self.cached_binary_path = Some(resolved_path.clone());
+                return Ok(resolved_path);
+            }
+
+            return Err(format!(
+                "Configured binaryPath '{path}' does not exist or is not accessible"
+            ));
         }
 
         if let Some(path) = worktree.which("intl-lens") {
             self.cached_binary_path = Some(path.clone());
             return Ok(path);
+        }
+
+        if let Some(path) = &self.cached_binary_path {
+            if std::fs::metadata(path).is_ok() {
+                return Ok(path.clone());
+            }
         }
 
         zed::set_language_server_installation_status(
@@ -108,6 +201,47 @@ impl IntlLensExtension {
 
         self.cached_binary_path = Some(binary_path.clone());
         Ok(binary_path)
+    }
+}
+
+impl IntlLensSettings {
+    fn normalized_binary_path(&self) -> Option<String> {
+        self.binary_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(ToOwned::to_owned)
+    }
+
+    fn normalized_server_settings(&self) -> IntlLensServerSettings {
+        let locale_paths = self.locale_paths.as_ref().and_then(|paths| {
+            let sanitized: Vec<String> = paths
+                .iter()
+                .map(|path| path.trim())
+                .filter(|path| !path.is_empty())
+                .map(ToOwned::to_owned)
+                .collect();
+            (!sanitized.is_empty()).then_some(sanitized)
+        });
+
+        let source_locale = self
+            .source_locale
+            .as_deref()
+            .map(str::trim)
+            .filter(|locale| !locale.is_empty())
+            .map(ToOwned::to_owned);
+
+        IntlLensServerSettings {
+            locale_paths,
+            source_locale,
+        }
+    }
+
+    fn server_settings_json(&self) -> serde_json::Value {
+        serde_json::to_value(self.normalized_server_settings()).unwrap_or_else(|err| {
+            eprintln!("Failed to serialize Intl Lens server settings: {err}");
+            json!({})
+        })
     }
 }
 

--- a/crates/intl-lens/Cargo.toml
+++ b/crates/intl-lens/Cargo.toml
@@ -22,3 +22,6 @@ dashmap.workspace = true
 regex.workspace = true
 globset.workspace = true
 walkdir.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/intl-lens/src/backend.rs
+++ b/crates/intl-lens/src/backend.rs
@@ -7,7 +7,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
-use crate::config::I18nConfig;
+use crate::config::{I18nConfig, I18nConfigOverrides};
 use crate::document::DocumentStore;
 use crate::i18n::{KeyFinder, TranslationStore};
 
@@ -49,15 +49,23 @@ impl I18nBackend {
         }
     }
 
-    async fn initialize_workspace(&self, root: PathBuf) {
+    async fn initialize_workspace(&self, root: PathBuf, overrides: I18nConfigOverrides) {
         tracing::info!("Initializing workspace at {:?}", root);
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!(
+                    "intl-lens initialize: root={:?}, overrides={:?}",
+                    root, overrides
+                ),
+            )
+            .await;
+        let config = I18nConfig::load_from_workspace_with_overrides(&root, &overrides);
+        self.apply_runtime_config(root, config).await;
+    }
 
-        let config = I18nConfig::load_from_workspace(&root);
+    async fn apply_runtime_config(&self, root: PathBuf, config: I18nConfig) {
         tracing::info!("Config loaded, locale_paths: {:?}", config.locale_paths);
-
-        let key_finder = KeyFinder::new(&config.function_patterns);
-        *self.key_finder.write().await = key_finder;
-
         let store = TranslationStore::new(root.clone());
         store.scan_and_load(&config.locale_paths);
 
@@ -71,17 +79,46 @@ impl I18nBackend {
             .log_message(
                 MessageType::INFO,
                 format!(
-                    "i18n-lsp initialized: {} locales, {} keys in {:?}",
+                    "intl-lens config applied: root={:?}, locale_paths={:?}, source_locale={}, locales={}, keys={}",
+                    root,
+                    config.locale_paths,
+                    config.source_locale,
                     locales.len(),
                     keys.len(),
-                    root
                 ),
             )
             .await;
 
+        let key_finder = KeyFinder::new(&config.function_patterns);
+        *self.key_finder.write().await = key_finder;
         *self.translation_store.write().await = Some(store);
         *self.config.write().await = config;
         *self.workspace_root.write().await = Some(root);
+        self.rediagnose_open_documents().await;
+        self.refresh_inlay_hints().await;
+    }
+
+    async fn apply_settings_overrides(&self, overrides: I18nConfigOverrides) {
+        let Some(root) = self.workspace_root.read().await.clone() else {
+            tracing::warn!("Ignoring configuration update without a workspace root");
+            return;
+        };
+
+        let previous_config = self.config.read().await.clone();
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!(
+                    "intl-lens configuration update: root={:?}, previous_locale_paths={:?}, previous_source_locale={}, overrides={:?}",
+                    root,
+                    previous_config.locale_paths,
+                    previous_config.source_locale,
+                    overrides
+                ),
+            )
+            .await;
+        let config = I18nConfig::load_from_workspace_with_overrides(&root, &overrides);
+        self.apply_runtime_config(root, config).await;
     }
 
     async fn register_inlay_hint_capability(&self) {
@@ -249,9 +286,21 @@ impl I18nBackend {
         };
 
         let mut diagnostics = Vec::new();
+        let mut missing_translation_logs = Vec::new();
+        let workspace_root = self.workspace_root.read().await.clone();
+        let locale_paths = self.config.read().await.locale_paths.clone();
 
         for found_key in found_keys {
             if !store.key_exists(&found_key.key) {
+                let locales = store.get_locales();
+                missing_translation_logs.push(format!(
+                    "intl-lens missing-translation: key={}, root={:?}, locale_paths={:?}, locales_loaded={}, key_exists_any={}",
+                    found_key.key,
+                    workspace_root,
+                    locale_paths,
+                    locales.len(),
+                    store.key_exists(&found_key.key),
+                ));
                 diagnostics.push(Diagnostic {
                     range: Range {
                         start: Position {
@@ -295,6 +344,12 @@ impl I18nBackend {
                     });
                 }
             }
+        }
+
+        drop(translation_store);
+
+        for message in missing_translation_logs {
+            self.client.log_message(MessageType::INFO, message).await;
         }
 
         diagnostics
@@ -541,6 +596,7 @@ impl I18nBackend {
             .await;
 
         *self.translation_store.write().await = Some(store);
+        self.rediagnose_open_documents().await;
         self.refresh_inlay_hints().await;
     }
 
@@ -548,6 +604,31 @@ impl I18nBackend {
         if *self.inlay_hint_refresh_supported.read().await {
             if let Err(err) = self.client.inlay_hint_refresh().await {
                 tracing::warn!("Inlay hint refresh failed: {:?}", err);
+            }
+        }
+    }
+
+    async fn rediagnose_open_documents(&self) {
+        let documents = { self.documents.read().await.snapshot() };
+        for (uri, content) in documents {
+            let Ok(parsed_uri) = Url::parse(&uri) else {
+                tracing::warn!("Skipping diagnostics refresh for invalid URI: {}", uri);
+                continue;
+            };
+
+            self.diagnose_document(&parsed_uri, &content).await;
+        }
+    }
+
+    fn parse_config_overrides(
+        value: serde_json::Value,
+        context: &str,
+    ) -> Option<I18nConfigOverrides> {
+        match serde_json::from_value::<I18nConfigOverrides>(value) {
+            Ok(overrides) => Some(overrides),
+            Err(err) => {
+                tracing::warn!("Ignoring invalid {}: {:?}", context, err);
+                None
             }
         }
     }
@@ -680,8 +761,14 @@ impl LanguageServer for I18nBackend {
                     .and_then(|uri| uri.to_file_path().ok())
             });
 
+        let initialization_overrides = params
+            .initialization_options
+            .and_then(|value| Self::parse_config_overrides(value, "initialization options"))
+            .unwrap_or_default();
+
         if let Some(root) = root_path {
-            self.initialize_workspace(root).await;
+            self.initialize_workspace(root, initialization_overrides)
+                .await;
         } else {
             tracing::warn!("No workspace root found in initialize params");
         }
@@ -749,6 +836,16 @@ impl LanguageServer for I18nBackend {
             tracing::info!("Translation files changed, reloading...");
             self.reload_translations().await;
         }
+    }
+
+    async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
+        let Some(overrides) =
+            Self::parse_config_overrides(params.settings, "workspace configuration")
+        else {
+            return;
+        };
+
+        self.apply_settings_overrides(overrides).await;
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {

--- a/crates/intl-lens/src/config.rs
+++ b/crates/intl-lens/src/config.rs
@@ -23,6 +23,13 @@ pub struct I18nConfig {
     pub function_patterns: Vec<String>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct I18nConfigOverrides {
+    pub locale_paths: Option<Vec<String>>,
+    pub source_locale: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum KeyStyle {
@@ -45,11 +52,10 @@ impl Default for I18nConfig {
 }
 
 impl I18nConfig {
-    pub fn load_from_workspace(root: &Path) -> Self {
+    pub fn effective_with_overrides(root: &Path, overrides: &I18nConfigOverrides) -> Self {
         let config_paths = [
             root.join(".i18n-ally.json"),
             root.join("i18n-ally.config.json"),
-            root.join(".zed/i18n.json"),
         ];
 
         for config_path in config_paths {
@@ -69,6 +75,7 @@ impl I18nConfig {
                         config.add_detected_locale_paths(root);
                     }
 
+                    config.apply_overrides(overrides);
                     tracing::info!("Loaded config from {:?}", config_path);
                     return config;
                 }
@@ -78,7 +85,25 @@ impl I18nConfig {
         tracing::info!("Using default config");
         let mut config = Self::default();
         config.add_detected_locale_paths(root);
+        config.apply_overrides(overrides);
         config
+    }
+
+    pub fn load_from_workspace_with_overrides(
+        root: &Path,
+        overrides: &I18nConfigOverrides,
+    ) -> Self {
+        Self::effective_with_overrides(root, overrides)
+    }
+
+    pub fn apply_overrides(&mut self, overrides: &I18nConfigOverrides) {
+        if let Some(locale_paths) = overrides.sanitized_locale_paths() {
+            self.locale_paths = locale_paths;
+        }
+
+        if let Some(source_locale) = overrides.sanitized_source_locale() {
+            self.source_locale = source_locale;
+        }
     }
 
     fn add_detected_locale_paths(&mut self, root: &Path) {
@@ -93,6 +118,29 @@ impl I18nConfig {
                 self.locale_paths.push(path);
             }
         }
+    }
+}
+
+impl I18nConfigOverrides {
+    pub fn sanitized_locale_paths(&self) -> Option<Vec<String>> {
+        self.locale_paths.as_ref().and_then(|paths| {
+            let sanitized: Vec<String> = paths
+                .iter()
+                .map(|path| path.trim())
+                .filter(|path| !path.is_empty())
+                .map(ToOwned::to_owned)
+                .collect();
+
+            (!sanitized.is_empty()).then_some(sanitized)
+        })
+    }
+
+    pub fn sanitized_source_locale(&self) -> Option<String> {
+        self.source_locale
+            .as_deref()
+            .map(str::trim)
+            .filter(|locale| !locale.is_empty())
+            .map(ToOwned::to_owned)
     }
 }
 
@@ -273,4 +321,51 @@ fn is_vue_project(root: &Path) -> bool {
         || root.join("vite.config.js").exists()
         || root.join("vite.config.ts").exists()
         || root.join("nuxt.config.js").exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_effective_config_applies_overrides_over_defaults() {
+        let dir = tempdir().unwrap();
+        let overrides = I18nConfigOverrides {
+            locale_paths: Some(vec!["apps/admin/src/assets/locales".into()]),
+            source_locale: Some("vi".into()),
+        };
+
+        let config = I18nConfig::effective_with_overrides(dir.path(), &overrides);
+
+        assert_eq!(
+            config.locale_paths,
+            vec!["apps/admin/src/assets/locales".to_string()]
+        );
+        assert_eq!(config.source_locale, "vi".to_string());
+    }
+
+    #[test]
+    fn test_load_from_workspace_with_overrides_matches_effective_config() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".i18n-ally.json"),
+            r#"{
+                "localePaths": ["src/locales"],
+                "sourceLocale": "en"
+            }"#,
+        )
+        .unwrap();
+
+        let overrides = I18nConfigOverrides {
+            locale_paths: Some(vec!["apps/admin/src/assets/locales".into()]),
+            source_locale: Some("vi".into()),
+        };
+
+        let config = I18nConfig::load_from_workspace_with_overrides(dir.path(), &overrides);
+        let effective = I18nConfig::effective_with_overrides(dir.path(), &overrides);
+
+        assert_eq!(config.locale_paths, effective.locale_paths);
+        assert_eq!(config.source_locale, effective.source_locale);
+    }
 }

--- a/crates/intl-lens/src/document.rs
+++ b/crates/intl-lens/src/document.rs
@@ -34,6 +34,13 @@ impl DocumentStore {
     pub fn get(&self, uri: &str) -> Option<&Document> {
         self.documents.get(uri)
     }
+
+    pub fn snapshot(&self) -> Vec<(String, String)> {
+        self.documents
+            .iter()
+            .map(|(uri, document)| (uri.clone(), document.content.clone()))
+            .collect()
+    }
 }
 
 impl Default for DocumentStore {

--- a/crates/intl-lens/src/i18n/store.rs
+++ b/crates/intl-lens/src/i18n/store.rs
@@ -277,3 +277,43 @@ fn extract_locale_from_arb_filename(file_stem: &str) -> Option<String> {
 
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_scan_and_load_relative_locale_path_finds_flat_keys() {
+        let dir = tempdir().unwrap();
+        let locale_dir = dir.path().join("apps/admin/src/assets/locales");
+        std::fs::create_dir_all(&locale_dir).unwrap();
+        std::fs::write(
+            locale_dir.join("en.json"),
+            r#"{
+                "mycard_page": "Prepaid Card Website Settings"
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            locale_dir.join("vi.json"),
+            r#"{
+                "mycard_page": "Thiết lập web quản lý thẻ trả trước"
+            }"#,
+        )
+        .unwrap();
+
+        let store = TranslationStore::new(dir.path().to_path_buf());
+        store.scan_and_load(&["apps/admin/src/assets/locales".to_string()]);
+
+        assert!(store.key_exists("mycard_page"));
+        assert_eq!(
+            store.get_translation("mycard_page", "en"),
+            Some("Prepaid Card Website Settings".to_string())
+        );
+        assert_eq!(
+            store.get_translation("mycard_page", "vi"),
+            Some("Thiết lập web quản lý thẻ trả trước".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## Summary
This PR migrates `intl-lens` to Zed's extension settings system and makes that configuration visible in the main Settings UI.

Previously, project configuration for `intl-lens` lived in sidecar files such as `.zed/i18n.json`, while extension-level behavior and language-server startup were handled separately. That made the configuration model harder to discover and harder to align with how other Zed settings work.

With this change, `intl-lens` reads its project and user overrides from:
- `extensions.intl-lens.localePaths`
- `extensions.intl-lens.sourceLocale`

inside `.zed/settings.json` and user settings.

## Why this is needed
- `intl-lens` should use the same settings model as other Zed features and extensions.
- Users should be able to configure the extension from the Settings UI instead of learning a separate `.zed/i18n.json` file format.
- Project settings should override user settings in a predictable way through Zed's normal settings precedence.
- The extension needs better observability so configuration-loading issues can be diagnosed from Zed logs.

## What this PR changes
- Read effective settings from `extensions.intl-lens` via the extension settings API.
- Treat `.zed/settings.json` as the primary project configuration path for `localePaths` and `sourceLocale`.
- Remove the old `.zed/i18n.json`-based project configuration flow.
- Prefer local `intl-lens` binaries during development, while keeping `binaryPath` as an internal compatibility override for debugging.
- Add runtime logging around configuration loading, effective config, and translation scanning.
- Add tests for config override handling and relative `localePaths` scanning.

## Why this pairs with the Zed change
This PR is the first concrete consumer of the new extension settings system.

It demonstrates the intended workflow:
- the extension contributes a schema,
- Zed renders that configuration in Settings,
- the extension reads the effective merged value,
- and the language server receives a single, consistent configuration source.

## Test plan
- [x] `cargo check -p intl-lens-extension -p intl-lens`
- [x] `cargo test -p intl-lens`
