### PR TITLE
feat: add namespace support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rs text eol=lf

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ Create `.zed/i18n.json` in your project root:
 ```json
 {
   "localePaths": ["src/locales", "public/locales"],
-  "sourceLocale": "en"
+  "sourceLocale": "en",
+  "namespaceEnabled": true
 }
 ```
 
@@ -144,6 +145,7 @@ Create `.zed/i18n.json` in your project root:
 | `localePaths` | `string[]` | `["locales", "i18n", ...]` | Where to find translation files |
 | `sourceLocale` | `string` | `"en"` | Your primary language |
 | `keyStyle` | `"nested" \| "flat"` | `"auto"` | JSON structure style |
+| `namespaceEnabled` | `boolean` | `false` | Prefix keys with the relative file path after the locale segment, e.g. `en/action.json -> action.*` |
 | `functionPatterns` | `string[]` | See below | Custom regex patterns |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Create `.zed/i18n.json` in your project root:
 | Format | Extensions |
 |--------|------------|
 | JSON | `.json` |
+| JavaScript | `.js` |
 | YAML | `.yaml` `.yml` |
 | PHP | `.php` |
 | ARB (Flutter) | `.arb` |
@@ -191,6 +192,16 @@ locales/
 ├── en.json
 ├── vi.json
 └── ja.json
+```
+
+**JavaScript export structure:**
+```js
+// locales/en.js
+export default {
+  common: {
+    save: "Save"
+  }
+}
 ```
 
 **Flutter ARB structure:**

--- a/crates/intl-lens/src/audit.rs
+++ b/crates/intl-lens/src/audit.rs
@@ -242,7 +242,7 @@ impl AuditResult {
             let full_path = self.workspace_root.join(path);
             if full_path.exists() {
                 // Try to find the locale file
-                for ext in ["json", "yaml", "yml"] {
+                for ext in ["json", "js", "yaml", "yml"] {
                     let file_path = full_path.join(format!("{}.{}", locale, ext));
                     if file_path.exists() {
                         return Some(file_path);
@@ -333,6 +333,44 @@ mod tests {
 
         assert_eq!(report.placeholder_issues.len(), 1);
         assert_eq!(report.placeholder_issues[0].key, "greeting");
+
+        fs::remove_dir_all(workspace).expect("cleanup temp workspace");
+    }
+
+    #[test]
+    fn suggests_js_locale_file_for_missing_translation() {
+        let workspace = temp_workspace("audit-js-suggestion");
+        let locales_dir = workspace.join("locales");
+        let src_dir = workspace.join("src");
+        fs::create_dir_all(&locales_dir).expect("create locales dir");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            locales_dir.join("en.js"),
+            r#"export default { common: { save: "Save" } };"#,
+        )
+        .expect("write en translations");
+        fs::write(locales_dir.join("vi.js"), r#"export default {};"#)
+            .expect("write vi translations");
+        fs::write(src_dir.join("app.ts"), r#"t("common.save");"#).expect("write source file");
+
+        let config = I18nConfig::default();
+        let store = TranslationStore::new(workspace.clone());
+        store.scan_and_load_with_config(&config);
+
+        let mut audit = AuditResult::new(workspace.clone(), config, store);
+        audit.scan_codebase();
+        let report = audit.generate_report();
+
+        let missing = report
+            .missing
+            .into_iter()
+            .find(|item| item.key == "common.save")
+            .expect("missing translation should be reported");
+        let suggestion = missing
+            .suggestion
+            .expect("missing translation should include suggestion");
+
+        assert_eq!(suggestion.files_to_edit, vec![locales_dir.join("vi.js")]);
 
         fs::remove_dir_all(workspace).expect("cleanup temp workspace");
     }

--- a/crates/intl-lens/src/audit.rs
+++ b/crates/intl-lens/src/audit.rs
@@ -326,7 +326,7 @@ mod tests {
 
         let config = I18nConfig::default();
         let store = TranslationStore::new(workspace.clone());
-        store.scan_and_load(&config.locale_paths);
+        store.scan_and_load_with_config(&config);
 
         let audit = AuditResult::new(workspace.clone(), config, store);
         let report = audit.generate_report();

--- a/crates/intl-lens/src/backend.rs
+++ b/crates/intl-lens/src/backend.rs
@@ -453,8 +453,8 @@ impl I18nBackend {
         }
     }
 
-    fn translation_extensions() -> [&'static str; 5] {
-        [".json", ".yaml", ".yml", ".php", ".arb"]
+    fn translation_extensions() -> [&'static str; 6] {
+        [".json", ".js", ".yaml", ".yml", ".php", ".arb"]
     }
 
     fn has_translation_extension(path: &Path) -> bool {
@@ -988,5 +988,20 @@ impl I18nBackend {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::I18nBackend;
+
+    #[test]
+    fn recognizes_js_translation_files() {
+        assert!(I18nBackend::has_translation_extension(Path::new(
+            "locales/en.js"
+        )));
+        assert!(I18nBackend::is_translation_file_path("locales/en.js"));
     }
 }

--- a/crates/intl-lens/src/backend.rs
+++ b/crates/intl-lens/src/backend.rs
@@ -59,7 +59,7 @@ impl I18nBackend {
         *self.key_finder.write().await = key_finder;
 
         let store = TranslationStore::new(root.clone());
-        store.scan_and_load(&config.locale_paths);
+        store.scan_and_load_with_config(&config);
 
         let locales = store.get_locales();
         let keys = store.get_all_keys();
@@ -517,14 +517,14 @@ impl I18nBackend {
 
     async fn reload_translations(&self) {
         let workspace_root = { self.workspace_root.read().await.clone() };
-        let locale_paths = { self.config.read().await.locale_paths.clone() };
+        let config = { self.config.read().await.clone() };
 
         let Some(root) = workspace_root.as_ref() else {
             return;
         };
 
         let store = TranslationStore::new(root.clone());
-        store.scan_and_load(&locale_paths);
+        store.scan_and_load_with_config(&config);
 
         let locales = store.get_locales();
         let keys = store.get_all_keys();

--- a/crates/intl-lens/src/cli.rs
+++ b/crates/intl-lens/src/cli.rs
@@ -113,7 +113,7 @@ async fn run_audit(
 
     pb.set_message("Scanning translation files...");
     let store = TranslationStore::new(workspace.clone());
-    store.scan_and_load(&config.locale_paths);
+    store.scan_and_load_with_config(&config);
 
     pb.set_message("Scanning codebase...");
     let mut result = AuditResult::new(workspace.clone(), config, store);
@@ -179,7 +179,7 @@ async fn run_check(
 
     // Load translations to check existence
     let store = TranslationStore::new(workspace.clone());
-    store.scan_and_load(&config.locale_paths);
+    store.scan_and_load_with_config(&config);
 
     let mut missing = Vec::new();
     let mut found = Vec::new();

--- a/crates/intl-lens/src/cli.rs
+++ b/crates/intl-lens/src/cli.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
 use colored::Colorize;
@@ -95,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_audit(
-    workspace: &PathBuf,
+    workspace: &Path,
     format: OutputFormat,
     output: Option<PathBuf>,
     missing_in: Option<String>,
@@ -112,11 +112,11 @@ async fn run_audit(
     let config = I18nConfig::load_from_workspace(workspace);
 
     pb.set_message("Scanning translation files...");
-    let store = TranslationStore::new(workspace.clone());
+    let store = TranslationStore::new(workspace.to_path_buf());
     store.scan_and_load_with_config(&config);
 
     pb.set_message("Scanning codebase...");
-    let mut result = AuditResult::new(workspace.clone(), config, store);
+    let mut result = AuditResult::new(workspace.to_path_buf(), config, store);
     result.scan_codebase();
 
     pb.set_message("Generating report...");
@@ -159,7 +159,7 @@ async fn run_audit(
 }
 
 async fn run_check(
-    workspace: &PathBuf,
+    workspace: &Path,
     files: Vec<PathBuf>,
     format: OutputFormat,
     output: Option<PathBuf>,
@@ -178,7 +178,7 @@ async fn run_check(
     }
 
     // Load translations to check existence
-    let store = TranslationStore::new(workspace.clone());
+    let store = TranslationStore::new(workspace.to_path_buf());
     store.scan_and_load_with_config(&config);
 
     let mut missing = Vec::new();
@@ -378,7 +378,7 @@ fn format_terminal(report: &intl_lens::audit::AuditReport, suggest_fixes: bool) 
             ));
 
             if !item.used_in.is_empty() {
-                output.push_str(&format!("    Used in:\n"));
+                output.push_str("    Used in:\n");
                 for usage in &item.used_in {
                     output.push_str(&format!(
                         "      - {}:{}\n",
@@ -388,8 +388,7 @@ fn format_terminal(report: &intl_lens::audit::AuditReport, suggest_fixes: bool) 
                 }
             }
 
-            if suggest_fixes && item.suggestion.is_some() {
-                let sugg = item.suggestion.as_ref().unwrap();
+            if let (true, Some(sugg)) = (suggest_fixes, item.suggestion.as_ref()) {
                 output.push_str(&format!(
                     "    {} {}\n",
                     "→".green(),
@@ -397,7 +396,7 @@ fn format_terminal(report: &intl_lens::audit::AuditReport, suggest_fixes: bool) 
                 ));
                 output.push_str(&format!("      Action: {}\n", sugg.action.green()));
                 if !sugg.files_to_edit.is_empty() {
-                    output.push_str(&format!("      Files to edit:\n"));
+                    output.push_str("      Files to edit:\n");
                     for f in &sugg.files_to_edit {
                         output
                             .push_str(&format!("        - {}\n", f.display().to_string().green()));
@@ -434,7 +433,7 @@ fn format_terminal(report: &intl_lens::audit::AuditReport, suggest_fixes: bool) 
                 "    Expected placeholders: {}\n",
                 item.expected_placeholders.join(", ").cyan()
             ));
-            output.push_str(&format!("    Mismatched locales:\n"));
+            output.push_str("    Mismatched locales:\n");
             for (locale, value) in &item.locale_values {
                 output.push_str(&format!("      {}: {}\n", locale.red(), value));
             }
@@ -457,8 +456,8 @@ fn format_markdown(report: &intl_lens::audit::AuditReport, suggest_fixes: bool) 
 
     // Summary
     md.push_str("## Summary\n\n");
-    md.push_str(&format!("| Metric | Count |\n"));
-    md.push_str(&format!("|--------|-------|\n"));
+    md.push_str("| Metric | Count |\n");
+    md.push_str("|--------|-------|\n");
     md.push_str(&format!("| Total Keys | {} |\n", report.summary.total_keys));
     md.push_str(&format!(
         "| Total Locales | {} |\n",
@@ -512,9 +511,8 @@ fn format_markdown(report: &intl_lens::audit::AuditReport, suggest_fixes: bool) 
                 }
             }
 
-            if suggest_fixes && item.suggestion.is_some() {
-                let sugg = item.suggestion.as_ref().unwrap();
-                md.push_str(&format!("\n**Suggestion:**\n"));
+            if let (true, Some(sugg)) = (suggest_fixes, item.suggestion.as_ref()) {
+                md.push_str("\n**Suggestion:**\n");
                 md.push_str(&format!("- Action: `{}`\n", sugg.action));
                 if !sugg.files_to_edit.is_empty() {
                     md.push_str("- Files to edit:\n");

--- a/crates/intl-lens/src/i18n/parser.rs
+++ b/crates/intl-lens/src/i18n/parser.rs
@@ -16,6 +16,7 @@ impl TranslationParser {
             "yaml" | "yml" => Self::parse_yaml(&content),
             "php" => Self::parse_php(&content),
             "arb" => Self::parse_arb(&content),
+            "js" => Self::parse_js(&content),
             _ => Self::parse_json(&content),
         }
     }
@@ -62,6 +63,14 @@ impl TranslationParser {
         let value: YamlValue = serde_yaml::from_str(content)?;
         let mut result = HashMap::new();
         Self::flatten_yaml(&value, String::new(), &mut result);
+        Ok(result)
+    }
+
+    pub fn parse_js(content: &str) -> Result<HashMap<String, String>> {
+        let mut parser = JsParser::new(content);
+        let value = parser.parse_root_object()?;
+        let mut result = HashMap::new();
+        flatten_js(&value, String::new(), &mut result);
         Ok(result)
     }
 
@@ -452,6 +461,394 @@ impl<'a> PhpParser<'a> {
     }
 }
 
+#[derive(Debug, Clone)]
+enum JsValue {
+    String(String),
+    Number(String),
+    Bool(bool),
+    Null,
+    Object(Vec<(String, JsValue)>),
+    Array(Vec<JsValue>),
+}
+
+#[derive(Debug, Clone)]
+enum JsToken {
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    Colon,
+    Comma,
+    String(String),
+    Ident(String),
+    Number(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JsTokenKind {
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    Colon,
+    Comma,
+}
+
+struct JsLexer<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl<'a> JsLexer<'a> {
+    fn new(input: &'a str) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    fn next_token(&mut self) -> Option<JsToken> {
+        self.skip_whitespace_and_comments();
+
+        if self.pos >= self.input.len() {
+            return None;
+        }
+
+        let ch = self.next_char()?;
+        let token = match ch {
+            '{' => JsToken::LBrace,
+            '}' => JsToken::RBrace,
+            '[' => JsToken::LBracket,
+            ']' => JsToken::RBracket,
+            ':' => JsToken::Colon,
+            ',' => JsToken::Comma,
+            '\'' | '"' | '`' => JsToken::String(self.read_string(ch)),
+            _ if ch.is_ascii_digit() || ch == '-' => {
+                let mut number = String::new();
+                number.push(ch);
+                number.push_str(&self.read_number());
+                JsToken::Number(number)
+            }
+            _ if ch.is_alphabetic() || ch == '_' || ch == '$' => {
+                let mut ident = String::new();
+                ident.push(ch);
+                ident.push_str(&self.read_ident());
+                JsToken::Ident(ident)
+            }
+            _ => return self.next_token(),
+        };
+
+        Some(token)
+    }
+
+    fn skip_whitespace_and_comments(&mut self) {
+        loop {
+            while self.peek_char().is_some_and(|ch| ch.is_whitespace()) {
+                self.next_char();
+            }
+
+            if self.starts_with("//") {
+                self.consume_until("\n");
+                continue;
+            }
+
+            if self.starts_with("/*") {
+                self.pos += 2;
+                self.consume_until("*/");
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    fn consume_until(&mut self, delimiter: &str) {
+        while self.pos < self.input.len() {
+            if self.starts_with(delimiter) {
+                self.pos += delimiter.len();
+                break;
+            }
+            self.next_char();
+        }
+    }
+
+    fn starts_with(&self, s: &str) -> bool {
+        self.input[self.pos..].starts_with(s)
+    }
+
+    fn peek_char(&self) -> Option<char> {
+        self.input[self.pos..].chars().next()
+    }
+
+    fn next_char(&mut self) -> Option<char> {
+        let ch = self.peek_char()?;
+        self.pos += ch.len_utf8();
+        Some(ch)
+    }
+
+    fn read_string(&mut self, quote: char) -> String {
+        let mut result = String::new();
+
+        while let Some(ch) = self.next_char() {
+            if ch == quote {
+                break;
+            }
+
+            if ch == '\\' {
+                if let Some(escaped) = self.next_char() {
+                    let unescaped = match escaped {
+                        'n' => '\n',
+                        'r' => '\r',
+                        't' => '\t',
+                        '\\' => '\\',
+                        '\'' => '\'',
+                        '"' => '"',
+                        '`' => '`',
+                        other => other,
+                    };
+                    result.push(unescaped);
+                }
+            } else {
+                result.push(ch);
+            }
+        }
+
+        result
+    }
+
+    fn read_ident(&mut self) -> String {
+        let mut result = String::new();
+        while let Some(ch) = self.peek_char() {
+            if ch.is_alphanumeric() || ch == '_' || ch == '$' || ch == '-' {
+                result.push(ch);
+                self.next_char();
+            } else {
+                break;
+            }
+        }
+        result
+    }
+
+    fn read_number(&mut self) -> String {
+        let mut result = String::new();
+        while let Some(ch) = self.peek_char() {
+            if ch.is_ascii_digit() || ch == '.' {
+                result.push(ch);
+                self.next_char();
+            } else {
+                break;
+            }
+        }
+        result
+    }
+}
+
+struct JsParser<'a> {
+    lexer: JsLexer<'a>,
+    lookahead: Option<JsToken>,
+}
+
+impl<'a> JsParser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            lexer: JsLexer::new(input),
+            lookahead: None,
+        }
+    }
+
+    fn parse_root_object(&mut self) -> Result<JsValue> {
+        while let Some(token) = self.peek_token() {
+            match token {
+                JsToken::LBrace => return self.parse_object(),
+                _ => {
+                    self.next_token();
+                }
+            }
+        }
+
+        bail!("No JavaScript object found")
+    }
+
+    fn parse_object(&mut self) -> Result<JsValue> {
+        self.expect_kind(JsTokenKind::LBrace)?;
+        let mut items = Vec::new();
+
+        loop {
+            if self.peek_kind() == Some(JsTokenKind::RBrace) {
+                self.next_token();
+                break;
+            }
+
+            if self.peek_token().is_none() {
+                bail!("Unexpected end of input while parsing object");
+            }
+
+            let key = self.parse_object_key()?;
+            self.expect_kind(JsTokenKind::Colon)?;
+            let value = self.parse_value()?;
+            items.push((key, value));
+
+            if !self.consume_kind(JsTokenKind::Comma)
+                && self.peek_kind() != Some(JsTokenKind::RBrace)
+            {
+                bail!("Expected ',' or '}}' in object");
+            }
+        }
+
+        Ok(JsValue::Object(items))
+    }
+
+    fn parse_array(&mut self) -> Result<JsValue> {
+        self.expect_kind(JsTokenKind::LBracket)?;
+        let mut items = Vec::new();
+
+        loop {
+            if self.peek_kind() == Some(JsTokenKind::RBracket) {
+                self.next_token();
+                break;
+            }
+
+            if self.peek_token().is_none() {
+                bail!("Unexpected end of input while parsing array");
+            }
+
+            items.push(self.parse_value()?);
+
+            if !self.consume_kind(JsTokenKind::Comma)
+                && self.peek_kind() != Some(JsTokenKind::RBracket)
+            {
+                bail!("Expected ',' or ']' in array");
+            }
+        }
+
+        Ok(JsValue::Array(items))
+    }
+
+    fn parse_object_key(&mut self) -> Result<String> {
+        match self.next_token() {
+            Some(JsToken::String(value)) => Ok(value),
+            Some(JsToken::Ident(value)) => Ok(value),
+            Some(JsToken::Number(value)) => Ok(value),
+            other => bail!("Unexpected object key token: {:?}", other),
+        }
+    }
+
+    fn parse_value(&mut self) -> Result<JsValue> {
+        match self.peek_token() {
+            Some(JsToken::LBrace) => self.parse_object(),
+            Some(JsToken::LBracket) => self.parse_array(),
+            Some(JsToken::String(_)) => match self.next_token() {
+                Some(JsToken::String(value)) => Ok(JsValue::String(value)),
+                _ => bail!("Expected string"),
+            },
+            Some(JsToken::Number(_)) => match self.next_token() {
+                Some(JsToken::Number(value)) => Ok(JsValue::Number(value)),
+                _ => bail!("Expected number"),
+            },
+            Some(JsToken::Ident(_)) => match self.next_token() {
+                Some(JsToken::Ident(ident)) => match ident.as_str() {
+                    "true" => Ok(JsValue::Bool(true)),
+                    "false" => Ok(JsValue::Bool(false)),
+                    "null" | "undefined" => Ok(JsValue::Null),
+                    _ => Ok(JsValue::String(ident)),
+                },
+                _ => bail!("Expected identifier"),
+            },
+            Some(token) => {
+                self.next_token();
+                bail!("Unexpected token: {:?}", token)
+            }
+            None => bail!("Unexpected end of input"),
+        }
+    }
+
+    fn peek_token(&mut self) -> Option<JsToken> {
+        if self.lookahead.is_none() {
+            self.lookahead = self.lexer.next_token();
+        }
+        self.lookahead.clone()
+    }
+
+    fn next_token(&mut self) -> Option<JsToken> {
+        if self.lookahead.is_some() {
+            return self.lookahead.take();
+        }
+        self.lexer.next_token()
+    }
+
+    fn expect_kind(&mut self, kind: JsTokenKind) -> Result<()> {
+        if self.peek_kind() == Some(kind) {
+            self.next_token();
+            Ok(())
+        } else {
+            bail!("Expected token kind: {:?}", kind)
+        }
+    }
+
+    fn consume_kind(&mut self, kind: JsTokenKind) -> bool {
+        if self.peek_kind() == Some(kind) {
+            self.next_token();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn peek_kind(&mut self) -> Option<JsTokenKind> {
+        self.peek_token().and_then(js_token_kind)
+    }
+}
+
+fn js_token_kind(token: JsToken) -> Option<JsTokenKind> {
+    match token {
+        JsToken::LBrace => Some(JsTokenKind::LBrace),
+        JsToken::RBrace => Some(JsTokenKind::RBrace),
+        JsToken::LBracket => Some(JsTokenKind::LBracket),
+        JsToken::RBracket => Some(JsTokenKind::RBracket),
+        JsToken::Colon => Some(JsTokenKind::Colon),
+        JsToken::Comma => Some(JsTokenKind::Comma),
+        _ => None,
+    }
+}
+
+fn flatten_js(value: &JsValue, prefix: String, result: &mut HashMap<String, String>) {
+    match value {
+        JsValue::String(value) => {
+            if !prefix.is_empty() {
+                result.insert(prefix, value.clone());
+            }
+        }
+        JsValue::Number(value) => {
+            if !prefix.is_empty() {
+                result.insert(prefix, value.clone());
+            }
+        }
+        JsValue::Bool(value) => {
+            if !prefix.is_empty() {
+                result.insert(prefix, value.to_string());
+            }
+        }
+        JsValue::Null => {}
+        JsValue::Object(items) => {
+            for (key, entry) in items {
+                let new_prefix = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{}.{}", prefix, key)
+                };
+                flatten_js(entry, new_prefix, result);
+            }
+        }
+        JsValue::Array(items) => {
+            for (index, entry) in items.iter().enumerate() {
+                let new_prefix = if prefix.is_empty() {
+                    index.to_string()
+                } else {
+                    format!("{}.{}", prefix, index)
+                };
+                flatten_js(entry, new_prefix, result);
+            }
+        }
+    }
+}
+
 fn token_kind(token: PhpToken) -> Option<PhpTokenKind> {
     match token {
         PhpToken::LBracket => Some(PhpTokenKind::LBracket),
@@ -630,5 +1027,42 @@ mod tests {
             Some(&"{count, plural, =0{no items} =1{1 item} other{{count} items}}".to_string())
         );
         assert!(!result.contains_key("@itemCount"));
+    }
+
+    #[test]
+    fn test_parse_js_export_default_object() {
+        let js = r#"
+            export default {
+                common: {
+                    hello: "Hello",
+                    bye: 'Goodbye',
+                },
+                enabled: true,
+                items: ["One", "Two"],
+            };
+        "#;
+        let result = TranslationParser::parse_js(js).unwrap();
+        assert_eq!(result.get("common.hello"), Some(&"Hello".to_string()));
+        assert_eq!(result.get("common.bye"), Some(&"Goodbye".to_string()));
+        assert_eq!(result.get("enabled"), Some(&"true".to_string()));
+        assert_eq!(result.get("items.0"), Some(&"One".to_string()));
+        assert_eq!(result.get("items.1"), Some(&"Two".to_string()));
+    }
+
+    #[test]
+    fn test_parse_js_module_exports_with_comments() {
+        let js = r#"
+            // locale definitions
+            module.exports = {
+                greeting: `Hello`,
+                /* keep nested structure */
+                nested: {
+                    count: 3,
+                },
+            };
+        "#;
+        let result = TranslationParser::parse_js(js).unwrap();
+        assert_eq!(result.get("greeting"), Some(&"Hello".to_string()));
+        assert_eq!(result.get("nested.count"), Some(&"3".to_string()));
     }
 }

--- a/crates/intl-lens/src/i18n/store.rs
+++ b/crates/intl-lens/src/i18n/store.rs
@@ -122,9 +122,7 @@ impl TranslationStore {
         locale_index: Option<usize>,
         config: &I18nConfig,
     ) -> Option<String> {
-        let Some(file_name) = segments.last().copied() else {
-            return None;
-        };
+        let file_name = segments.last().copied()?;
 
         let file_stem = Path::new(file_name).file_stem()?.to_str()?;
         let extension = Path::new(file_name)
@@ -296,6 +294,64 @@ impl TranslationStore {
     }
 }
 
+fn is_locale_code(s: &str) -> bool {
+    let locale_patterns = [
+        r"^[a-z]{2}$",
+        r"^[a-z]{2,3}[-_][A-Z][a-z]{3}$",
+        r"^[a-z]{2}[-_][A-Z]{2}$",
+        r"^[a-z]{2}[-_][a-z]{2}$",
+        r"^[a-z]{2,3}[-_][A-Z][a-z]{3}[-_][A-Z]{2}$",
+    ];
+
+    for pattern in &locale_patterns {
+        if regex::Regex::new(pattern).unwrap().is_match(s) {
+            return true;
+        }
+    }
+
+    let common_locales = [
+        "en", "en-US", "en-GB", "es", "es-ES", "fr", "fr-FR", "de", "de-DE", "it", "it-IT", "pt",
+        "pt-BR", "ja", "ja-JP", "ko", "ko-KR", "zh", "zh-CN", "zh-TW", "zh-Hans", "zh-Hant", "ru",
+        "ru-RU", "ar", "ar-SA", "vi", "vi-VN",
+    ];
+
+    common_locales.contains(&s)
+}
+
+/// Extract locale from ARB filename patterns like "app_en", "messages_en_US", "intl_vi"
+fn extract_locale_from_arb_filename(file_stem: &str) -> Option<String> {
+    // Common ARB file prefixes
+    let prefixes = ["app_", "intl_", "messages_", "l10n_", "strings_"];
+
+    for prefix in prefixes {
+        if let Some(locale_part) = file_stem.strip_prefix(prefix) {
+            if is_locale_code(locale_part) {
+                return Some(locale_part.to_string());
+            }
+        }
+    }
+
+    // Try splitting by underscore and check if last part(s) form a locale
+    let parts: Vec<&str> = file_stem.split('_').collect();
+    if parts.len() >= 2 {
+        // Try last part as locale (e.g., "app_en" -> "en")
+        let last = parts[parts.len() - 1];
+        if is_locale_code(last) {
+            return Some(last.to_string());
+        }
+
+        // Try last two parts as locale (e.g., "app_en_US" -> "en_US")
+        if parts.len() >= 3 {
+            let locale = format!("{}_{}", parts[parts.len() - 2], parts[parts.len() - 1]);
+            if is_locale_code(&locale) {
+                return Some(locale);
+            }
+        }
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -456,62 +512,4 @@ mod tests {
 
         fs::remove_dir_all(workspace).expect("cleanup temp workspace");
     }
-}
-
-fn is_locale_code(s: &str) -> bool {
-    let locale_patterns = [
-        r"^[a-z]{2}$",
-        r"^[a-z]{2,3}[-_][A-Z][a-z]{3}$",
-        r"^[a-z]{2}[-_][A-Z]{2}$",
-        r"^[a-z]{2}[-_][a-z]{2}$",
-        r"^[a-z]{2,3}[-_][A-Z][a-z]{3}[-_][A-Z]{2}$",
-    ];
-
-    for pattern in &locale_patterns {
-        if regex::Regex::new(pattern).unwrap().is_match(s) {
-            return true;
-        }
-    }
-
-    let common_locales = [
-        "en", "en-US", "en-GB", "es", "es-ES", "fr", "fr-FR", "de", "de-DE", "it", "it-IT", "pt",
-        "pt-BR", "ja", "ja-JP", "ko", "ko-KR", "zh", "zh-CN", "zh-TW", "zh-Hans", "zh-Hant", "ru",
-        "ru-RU", "ar", "ar-SA", "vi", "vi-VN",
-    ];
-
-    common_locales.contains(&s)
-}
-
-/// Extract locale from ARB filename patterns like "app_en", "messages_en_US", "intl_vi"
-fn extract_locale_from_arb_filename(file_stem: &str) -> Option<String> {
-    // Common ARB file prefixes
-    let prefixes = ["app_", "intl_", "messages_", "l10n_", "strings_"];
-
-    for prefix in prefixes {
-        if let Some(locale_part) = file_stem.strip_prefix(prefix) {
-            if is_locale_code(locale_part) {
-                return Some(locale_part.to_string());
-            }
-        }
-    }
-
-    // Try splitting by underscore and check if last part(s) form a locale
-    let parts: Vec<&str> = file_stem.split('_').collect();
-    if parts.len() >= 2 {
-        // Try last part as locale (e.g., "app_en" -> "en")
-        let last = parts[parts.len() - 1];
-        if is_locale_code(last) {
-            return Some(last.to_string());
-        }
-
-        // Try last two parts as locale (e.g., "app_en_US" -> "en_US")
-        if parts.len() >= 3 {
-            let locale = format!("{}_{}", parts[parts.len() - 2], parts[parts.len() - 1]);
-            if is_locale_code(&locale) {
-                return Some(locale);
-            }
-        }
-    }
-
-    None
 }

--- a/crates/intl-lens/src/i18n/store.rs
+++ b/crates/intl-lens/src/i18n/store.rs
@@ -6,6 +6,8 @@ use globset::Glob;
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
+use crate::config::I18nConfig;
+
 use super::parser::TranslationParser;
 
 #[derive(Debug, Clone)]
@@ -33,26 +35,23 @@ impl TranslationStore {
         }
     }
 
-    pub fn scan_and_load(&self, locale_paths: &[String]) {
+    pub fn scan_and_load_with_config(&self, config: &I18nConfig) {
+        let locale_paths = &config.locale_paths;
         for locale_path in locale_paths {
             let full_path = self.workspace_root.join(locale_path);
             if full_path.exists() {
-                self.scan_directory(&full_path);
+                self.scan_directory(&full_path, config);
             }
         }
     }
 
-    fn scan_directory(&self, dir: &Path) {
+    fn scan_directory(&self, dir: &Path, config: &I18nConfig) {
         let json_glob = Glob::new("*.json").unwrap().compile_matcher();
         let yaml_glob = Glob::new("*.{yaml,yml}").unwrap().compile_matcher();
         let php_glob = Glob::new("*.php").unwrap().compile_matcher();
         let arb_glob = Glob::new("*.arb").unwrap().compile_matcher();
 
-        for entry in WalkDir::new(dir)
-            .max_depth(3)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
+        for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
             let path = entry.path();
             let file_name = path.file_name().unwrap_or_default();
 
@@ -62,18 +61,30 @@ impl TranslationStore {
                     || php_glob.is_match(file_name)
                     || arb_glob.is_match(file_name))
             {
-                if let Some(locale) = self.extract_locale_from_path(path) {
-                    self.load_translation_file(path, &locale);
+                if let Some((locale, namespace)) = self.extract_locale_from_path(dir, path, config)
+                {
+                    self.load_translation_file(path, &locale, namespace.as_deref());
                 }
             }
         }
     }
 
-    fn extract_locale_from_path(&self, path: &Path) -> Option<String> {
+    fn extract_locale_from_path(
+        &self,
+        locale_root: &Path,
+        path: &Path,
+        config: &I18nConfig,
+    ) -> Option<(String, Option<String>)> {
+        let relative = path.strip_prefix(locale_root).ok()?;
         let file_stem = path.file_stem()?.to_str()?;
+        let segments: Vec<&str> = relative
+            .iter()
+            .filter_map(|segment| segment.to_str())
+            .collect();
 
         if is_locale_code(file_stem) {
-            return Some(file_stem.to_string());
+            let namespace = self.build_namespace_from_segments(&segments, None, config);
+            return Some((file_stem.to_string(), namespace));
         }
 
         // Handle ARB naming convention: app_en.arb, app_es.arb, etc.
@@ -81,34 +92,78 @@ impl TranslationStore {
             if ext == "arb" {
                 // Try to extract locale from patterns like "app_en" or "messages_en_US"
                 if let Some(locale) = extract_locale_from_arb_filename(file_stem) {
-                    return Some(locale);
+                    let namespace = self.build_namespace_from_segments(&segments, None, config);
+                    return Some((locale, namespace));
                 }
             }
         }
 
-        if let Some(parent) = path.parent() {
-            if let Some(parent_name) = parent.file_name().and_then(|n| n.to_str()) {
-                if is_locale_code(parent_name) {
-                    return Some(parent_name.to_string());
-                }
+        for (index, segment) in segments.iter().enumerate().rev().skip(1) {
+            if is_locale_code(segment) {
+                let namespace = self.build_namespace_from_segments(&segments, Some(index), config);
+                return Some(((*segment).to_string(), namespace));
             }
         }
 
         None
     }
 
-    fn load_translation_file(&self, path: &Path, locale: &str) {
+    fn build_namespace_from_segments(
+        &self,
+        segments: &[&str],
+        locale_index: Option<usize>,
+        config: &I18nConfig,
+    ) -> Option<String> {
+        let Some(file_name) = segments.last().copied() else {
+            return None;
+        };
+
+        let file_stem = Path::new(file_name).file_stem()?.to_str()?;
+        let extension = Path::new(file_name)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .unwrap_or("");
+
+        if extension == "php" && !file_stem.is_empty() && !is_locale_code(file_stem) {
+            let mut namespace_parts: Vec<&str> = Vec::new();
+            if let Some(index) = locale_index {
+                namespace_parts.extend(
+                    segments
+                        .iter()
+                        .skip(index + 1)
+                        .take(segments.len() - index - 2),
+                );
+            }
+            namespace_parts.push(file_stem);
+            return Some(namespace_parts.join("."));
+        }
+
+        if !config.namespace_enabled || file_stem.is_empty() || is_locale_code(file_stem) {
+            return None;
+        }
+
+        let mut namespace_parts: Vec<&str> = Vec::new();
+        if let Some(index) = locale_index {
+            namespace_parts.extend(
+                segments
+                    .iter()
+                    .skip(index + 1)
+                    .take(segments.len() - index - 2),
+            );
+        }
+        namespace_parts.push(file_stem);
+
+        if namespace_parts.is_empty() {
+            None
+        } else {
+            Some(namespace_parts.join("."))
+        }
+    }
+
+    fn load_translation_file(&self, path: &Path, locale: &str, prefix: Option<&str>) {
         match TranslationParser::parse_file(path) {
             Ok(translations) => {
                 let mut locale_map = self.translations.entry(locale.to_string()).or_default();
-                let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-                let file_stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-                let prefix =
-                    if extension == "php" && !file_stem.is_empty() && !is_locale_code(file_stem) {
-                        Some(file_stem)
-                    } else {
-                        None
-                    };
 
                 for (key, value) in translations {
                     let full_key = match prefix {
@@ -220,6 +275,98 @@ impl TranslationStore {
                     .unwrap_or(true)
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::config::I18nConfig;
+
+    use super::TranslationStore;
+
+    fn temp_workspace(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("intl-lens-store-{name}-{unique}"))
+    }
+
+    #[test]
+    fn loads_json_file_name_as_namespace_when_enabled() {
+        let workspace = temp_workspace("namespace-top-level");
+        let locale_dir = workspace.join("src/locales/lang/en");
+        fs::create_dir_all(&locale_dir).expect("create locale directory");
+        fs::write(locale_dir.join("action.json"), r#"{"allocate":"Setting"}"#)
+            .expect("write translation file");
+
+        let config = I18nConfig {
+            locale_paths: vec!["src/locales".to_string()],
+            namespace_enabled: true,
+            ..I18nConfig::default()
+        };
+        let store = TranslationStore::new(workspace.clone());
+        store.scan_and_load_with_config(&config);
+
+        assert_eq!(
+            store.get_translation("action.allocate", "en"),
+            Some("Setting".to_string())
+        );
+
+        fs::remove_dir_all(workspace).expect("cleanup temp workspace");
+    }
+
+    #[test]
+    fn loads_nested_directories_as_namespace_when_enabled() {
+        let workspace = temp_workspace("namespace-nested");
+        let locale_dir = workspace.join("src/locales/lang/en/system");
+        fs::create_dir_all(&locale_dir).expect("create locale directory");
+        fs::write(locale_dir.join("user.json"), r#"{"title":"Users"}"#)
+            .expect("write translation file");
+
+        let config = I18nConfig {
+            locale_paths: vec!["src/locales".to_string()],
+            namespace_enabled: true,
+            ..I18nConfig::default()
+        };
+        let store = TranslationStore::new(workspace.clone());
+        store.scan_and_load_with_config(&config);
+
+        assert_eq!(
+            store.get_translation("system.user.title", "en"),
+            Some("Users".to_string())
+        );
+
+        fs::remove_dir_all(workspace).expect("cleanup temp workspace");
+    }
+
+    #[test]
+    fn keeps_previous_behavior_when_namespace_is_disabled() {
+        let workspace = temp_workspace("namespace-disabled");
+        let locale_dir = workspace.join("src/locales/lang/en");
+        fs::create_dir_all(&locale_dir).expect("create locale directory");
+        fs::write(locale_dir.join("action.json"), r#"{"allocate":"Setting"}"#)
+            .expect("write translation file");
+
+        let config = I18nConfig {
+            locale_paths: vec!["src/locales".to_string()],
+            namespace_enabled: false,
+            ..I18nConfig::default()
+        };
+        let store = TranslationStore::new(workspace.clone());
+        store.scan_and_load_with_config(&config);
+
+        assert_eq!(
+            store.get_translation("allocate", "en"),
+            Some("Setting".to_string())
+        );
+        assert_eq!(store.get_translation("action.allocate", "en"), None);
+
+        fs::remove_dir_all(workspace).expect("cleanup temp workspace");
     }
 }
 

--- a/crates/intl-lens/src/i18n/store.rs
+++ b/crates/intl-lens/src/i18n/store.rs
@@ -47,6 +47,7 @@ impl TranslationStore {
 
     fn scan_directory(&self, dir: &Path, config: &I18nConfig) {
         let json_glob = Glob::new("*.json").unwrap().compile_matcher();
+        let js_glob = Glob::new("*.js").unwrap().compile_matcher();
         let yaml_glob = Glob::new("*.{yaml,yml}").unwrap().compile_matcher();
         let php_glob = Glob::new("*.php").unwrap().compile_matcher();
         let arb_glob = Glob::new("*.arb").unwrap().compile_matcher();
@@ -57,6 +58,7 @@ impl TranslationStore {
 
             if path.is_file()
                 && (json_glob.is_match(file_name)
+                    || js_glob.is_match(file_name)
                     || yaml_glob.is_match(file_name)
                     || php_glob.is_match(file_name)
                     || arb_glob.is_match(file_name))
@@ -321,6 +323,44 @@ mod tests {
     }
 
     #[test]
+    fn loads_js_translation_files() {
+        let workspace = temp_workspace("js-translations");
+        let locale_dir = workspace.join("locales/en");
+        fs::create_dir_all(&locale_dir).expect("create locale directory");
+        fs::write(
+            locale_dir.join("common.js"),
+            r#"
+                export default {
+                    save: "Save",
+                    status: {
+                        ready: "Ready",
+                    },
+                };
+            "#,
+        )
+        .expect("write translation file");
+
+        let config = I18nConfig {
+            locale_paths: vec!["locales".to_string()],
+            namespace_enabled: true,
+            ..I18nConfig::default()
+        };
+        let store = TranslationStore::new(workspace.clone());
+        store.scan_and_load_with_config(&config);
+
+        assert_eq!(
+            store.get_translation("common.save", "en"),
+            Some("Save".to_string())
+        );
+        assert_eq!(
+            store.get_translation("common.status.ready", "en"),
+            Some("Ready".to_string())
+        );
+
+        fs::remove_dir_all(workspace).expect("cleanup temp workspace");
+    }
+
+    #[test]
     fn loads_nested_directories_as_namespace_when_enabled() {
         let workspace = temp_workspace("namespace-nested");
         let locale_dir = workspace.join("src/locales/lang/en/system");
@@ -368,13 +408,47 @@ mod tests {
 
         fs::remove_dir_all(workspace).expect("cleanup temp workspace");
     }
+
+    #[test]
+    fn loads_script_tag_locale_directories() {
+        let workspace = temp_workspace("locale-script-tag");
+        let locale_dir = workspace.join("src/locale/zh-Hans");
+        fs::create_dir_all(&locale_dir).expect("create locale directory");
+        fs::write(
+            locale_dir.join("common.js"),
+            r#"
+                export default {
+                    title: "你好",
+                };
+            "#,
+        )
+        .expect("write translation file");
+
+        let config = I18nConfig {
+            locale_paths: vec!["src/locale".to_string()],
+            source_locale: "zh-Hans".to_string(),
+            namespace_enabled: true,
+            ..I18nConfig::default()
+        };
+        let store = TranslationStore::new(workspace.clone());
+        store.scan_and_load_with_config(&config);
+
+        assert_eq!(
+            store.get_translation("common.title", "zh-Hans"),
+            Some("你好".to_string())
+        );
+
+        fs::remove_dir_all(workspace).expect("cleanup temp workspace");
+    }
 }
 
 fn is_locale_code(s: &str) -> bool {
     let locale_patterns = [
         r"^[a-z]{2}$",
+        r"^[a-z]{2,3}[-_][A-Z][a-z]{3}$",
         r"^[a-z]{2}[-_][A-Z]{2}$",
         r"^[a-z]{2}[-_][a-z]{2}$",
+        r"^[a-z]{2,3}[-_][A-Z][a-z]{3}[-_][A-Z]{2}$",
     ];
 
     for pattern in &locale_patterns {
@@ -385,8 +459,8 @@ fn is_locale_code(s: &str) -> bool {
 
     let common_locales = [
         "en", "en-US", "en-GB", "es", "es-ES", "fr", "fr-FR", "de", "de-DE", "it", "it-IT", "pt",
-        "pt-BR", "ja", "ja-JP", "ko", "ko-KR", "zh", "zh-CN", "zh-TW", "ru", "ru-RU", "ar",
-        "ar-SA", "vi", "vi-VN",
+        "pt-BR", "ja", "ja-JP", "ko", "ko-KR", "zh", "zh-CN", "zh-TW", "zh-Hans", "zh-Hant", "ru",
+        "ru-RU", "ar", "ar-SA", "vi", "vi-VN",
     ];
 
     common_locales.contains(&s)

--- a/crates/intl-lens/src/lib.rs
+++ b/crates/intl-lens/src/lib.rs
@@ -4,9 +4,12 @@ pub mod document;
 pub mod i18n;
 pub mod scanner;
 
+pub use audit::{
+    AuditReport, AuditResult, AuditSummary, FixSuggestion, KeyUsage, MissingTranslation,
+    PlaceholderIssue, PlaceholderIssueType, UnusedKey,
+};
 pub use config::{I18nConfig, KeyStyle};
-pub use i18n::store::{TranslationEntry, TranslationLocation, TranslationStore};
 pub use i18n::key_finder::{FoundKey, KeyFinder};
 pub use i18n::parser::TranslationParser;
-pub use audit::{AuditReport, AuditSummary, AuditResult, MissingTranslation, PlaceholderIssue, PlaceholderIssueType, UnusedKey, KeyUsage, FixSuggestion};
-pub use scanner::{CodeScanner, CodeKeyOccurrence, ScannedFile};
+pub use i18n::store::{TranslationEntry, TranslationLocation, TranslationStore};
+pub use scanner::{CodeKeyOccurrence, CodeScanner, ScannedFile};

--- a/crates/intl-lens/src/mcp.rs
+++ b/crates/intl-lens/src/mcp.rs
@@ -464,7 +464,7 @@ fn find_locale_file(workspace: &Path, locale: &str) -> Option<PathBuf> {
             continue;
         }
 
-        for extension in ["json", "yaml", "yml", "arb", "php"] {
+        for extension in ["json", "js", "yaml", "yml", "arb", "php"] {
             let candidate = base.join(format!("{}.{}", locale, extension));
             if candidate.exists() {
                 return Some(candidate);
@@ -662,5 +662,26 @@ mod tests {
         let text = String::from_utf8(output).expect("utf8 output");
         assert!(text.starts_with("Content-Length: "));
         assert!(text.contains("\r\n\r\n{\"jsonrpc\":\"2.0\""));
+    }
+
+    #[test]
+    fn finds_js_locale_file() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let workspace = std::env::temp_dir().join(format!("intl-lens-mcp-{unique}"));
+        let locales_dir = workspace.join("locales");
+        std::fs::create_dir_all(&locales_dir).expect("create locales dir");
+        std::fs::write(
+            locales_dir.join("en.js"),
+            "module.exports = { greeting: 'Hello' };",
+        )
+        .expect("write js locale file");
+
+        let found = find_locale_file(&workspace, "en");
+        assert_eq!(found, Some(locales_dir.join("en.js")));
+
+        std::fs::remove_dir_all(workspace).expect("cleanup temp workspace");
     }
 }

--- a/crates/intl-lens/src/mcp.rs
+++ b/crates/intl-lens/src/mcp.rs
@@ -435,7 +435,7 @@ impl McpServer {
     fn load_store(&self, workspace: &Path) -> (I18nConfig, TranslationStore) {
         let config = I18nConfig::load_from_workspace(workspace);
         let store = TranslationStore::new(workspace.to_path_buf());
-        store.scan_and_load(&config.locale_paths);
+        store.scan_and_load_with_config(&config);
         (config, store)
     }
 }


### PR DESCRIPTION
## Summary

Add namespace-aware key loading for file-based locale structures when `namespaceEnabled` is enabled.

This fixes projects where translation keys are derived from file paths, such as:

- `src/locales/lang/en/action.json` -> `action.allocate`
- `src/locales/lang/en/system/user.json` -> `system.user.title`

Without this change, those projects are indexed as `allocate` / `title`, which causes false `Translation key not found` diagnostics.

## Changes

- apply `namespaceEnabled` to JSON, YAML, and ARB translation files
- derive namespaces from the relative path after the locale segment
- preserve existing behavior when `namespaceEnabled` is disabled
- remove the shallow directory scan limit so nested locale files are discovered correctly

## Example

With `namespaceEnabled: true`:

- `src/locales/lang/en/action.json`
  - `{ "allocate": "Setting" }`
  - becomes `action.allocate`

- `src/locales/lang/en/system/user.json`
  - `{ "title": "Users" }`
  - becomes `system.user.title`

## Verification

- added tests covering:
  - top-level file namespaces
  - nested directory namespaces
  - backward-compatible behavior when `namespaceEnabled` is disabled
- ran `cargo test namespace -- --nocapture`
