### PR TITLE
fix: support Nuxt layer locale discovery

### DIFF
--- a/crates/intl-lens/src/backend.rs
+++ b/crates/intl-lens/src/backend.rs
@@ -516,6 +516,10 @@ impl I18nBackend {
                 continue;
             }
 
+            if Self::path_matches_locale_glob(path, root, trimmed) {
+                return true;
+            }
+
             let candidate = if Path::new(trimmed).is_absolute() {
                 PathBuf::from(trimmed)
             } else {
@@ -532,6 +536,29 @@ impl I18nBackend {
         }
 
         false
+    }
+
+    fn path_matches_locale_glob(path: &Path, root: &Path, pattern: &str) -> bool {
+        if !pattern.contains('*') && !pattern.contains('?') && !pattern.contains('[') {
+            return false;
+        }
+
+        let Ok(glob) = globset::Glob::new(pattern) else {
+            return false;
+        };
+        let matcher = glob.compile_matcher();
+
+        let Ok(relative_path) = path.strip_prefix(root) else {
+            return false;
+        };
+
+        if matcher.is_match(relative_path) {
+            return true;
+        }
+
+        relative_path
+            .parent()
+            .is_some_and(|parent| matcher.is_match(parent))
     }
 
     async fn is_translation_uri(&self, uri: &Url) -> bool {
@@ -1501,6 +1528,19 @@ mod tests {
     fn test_detect_indent_tab() {
         let content = "{\n\t\"hello\": \"world\"\n}";
         assert_eq!(I18nBackend::detect_indent_unit(content), "\t");
+    }
+
+    #[test]
+    fn test_translation_file_matches_glob_locale_directory() {
+        let root = Path::new("/workspace/project");
+        let path = Path::new("/workspace/project/layers/foo/i18n/locales/en.json");
+        let locale_paths = vec!["**/*/i18n/locales".to_string()];
+
+        assert!(I18nBackend::is_translation_file_in_paths(
+            path,
+            root,
+            &locale_paths
+        ));
     }
 
     #[test]

--- a/crates/intl-lens/src/config.rs
+++ b/crates/intl-lens/src/config.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct I18nConfig {
-    #[serde(default = "default_locale_paths")]
+    #[serde(default = "default_locale_paths", alias = "localesPaths")]
     pub locale_paths: Vec<String>,
 
     #[serde(default = "default_source_locale")]
@@ -63,6 +63,7 @@ impl I18nConfig {
                         .is_some_and(|object| {
                             object.contains_key("localePaths")
                                 || object.contains_key("locale_paths")
+                                || object.contains_key("localesPaths")
                         });
 
                     if !has_locale_paths {
@@ -185,9 +186,11 @@ fn detect_framework_locale_paths(root: &Path) -> Vec<String> {
     if is_vue_project(root) {
         paths.push("src/locales".to_string());
         paths.push("src/i18n".to_string());
+        paths.push("src/lang".to_string());
         paths.push("locales".to_string());
         paths.push("i18n".to_string());
         paths.push("public/locales".to_string());
+        paths.extend(detect_nuxt_layer_locale_paths(root));
     }
 
     if is_svelte_project(root) {
@@ -204,6 +207,34 @@ fn detect_framework_locale_paths(root: &Path) -> Vec<String> {
         .into_iter()
         .filter(|path| root.join(path).exists())
         .collect()
+}
+
+fn detect_nuxt_layer_locale_paths(root: &Path) -> Vec<String> {
+    let layers_dir = root.join("layers");
+    let Ok(entries) = std::fs::read_dir(layers_dir) else {
+        return Vec::new();
+    };
+
+    let mut paths = Vec::new();
+    for entry in entries.filter_map(|entry| entry.ok()) {
+        let layer_path = entry.path();
+        if !layer_path.is_dir() {
+            continue;
+        }
+
+        for locale_dir in ["i18n/locales", "i18n"] {
+            let candidate = layer_path.join(locale_dir);
+            if !candidate.is_dir() {
+                continue;
+            }
+
+            if let Ok(relative_path) = candidate.strip_prefix(root) {
+                paths.push(relative_path.to_string_lossy().replace('\\', "/"));
+            }
+        }
+    }
+
+    paths
 }
 
 fn is_angular_project(root: &Path) -> bool {
@@ -308,4 +339,57 @@ fn is_vue_project(root: &Path) -> bool {
         || root.join("vite.config.js").exists()
         || root.join("vite.config.ts").exists()
         || root.join("nuxt.config.js").exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    #[test]
+    fn detects_nuxt_layer_locale_paths() {
+        let root = test_workspace("nuxt-layer-detection");
+        fs::create_dir_all(root.join("layers/foo/i18n/locales")).expect("create layer locales");
+        fs::write(
+            root.join("nuxt.config.js"),
+            "export default defineNuxtConfig({})",
+        )
+        .expect("write nuxt config");
+        fs::write(
+            root.join("package.json"),
+            r#"{"dependencies":{"@nuxtjs/i18n":"10.2.1"}}"#,
+        )
+        .expect("write package json");
+
+        let config = I18nConfig::load_from_workspace(&root);
+
+        assert!(config
+            .locale_paths
+            .contains(&"layers/foo/i18n/locales".to_string()));
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn reads_i18n_ally_locales_paths_alias() {
+        let config = serde_json::from_str::<I18nConfig>(
+            r#"{"localesPaths":["src/lang","**/*/i18n/locales"]}"#,
+        )
+        .expect("parse i18n ally config");
+
+        assert_eq!(
+            config.locale_paths,
+            vec!["src/lang".to_string(), "**/*/i18n/locales".to_string()]
+        );
+    }
+
+    fn test_workspace(name: &str) -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("intl-lens-{name}-{nonce}"))
+    }
 }

--- a/crates/intl-lens/src/i18n/store.rs
+++ b/crates/intl-lens/src/i18n/store.rs
@@ -37,9 +37,50 @@ impl TranslationStore {
 
     pub fn scan_and_load(&self, locale_paths: &[String]) {
         for locale_path in locale_paths {
-            let full_path = self.workspace_root.join(locale_path);
-            if full_path.exists() {
+            let trimmed = locale_path.trim_end_matches(['/', '\\']);
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            if has_glob_meta(trimmed) {
+                self.scan_glob_path(trimmed);
+                continue;
+            }
+
+            let full_path = self.workspace_root.join(trimmed);
+            if full_path.is_file() {
+                self.scan_file(&full_path);
+            } else if full_path.exists() {
                 self.scan_directory(&full_path);
+            }
+        }
+    }
+
+    fn scan_glob_path(&self, locale_path: &str) {
+        let Ok(glob) = Glob::new(locale_path) else {
+            tracing::warn!("Invalid locale path glob: {}", locale_path);
+            return;
+        };
+        let matcher = glob.compile_matcher();
+
+        for entry in WalkDir::new(&self.workspace_root)
+            .into_iter()
+            .filter_entry(|entry| !is_ignored_workspace_dir(entry.path()))
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            let Ok(relative_path) = path.strip_prefix(&self.workspace_root) else {
+                continue;
+            };
+
+            if !matcher.is_match(relative_path) {
+                continue;
+            }
+
+            if path.is_dir() {
+                self.scan_directory(path);
+            } else if path.is_file() {
+                self.scan_file(path);
             }
         }
     }
@@ -64,14 +105,18 @@ impl TranslationStore {
                     || php_glob.is_match(file_name)
                     || arb_glob.is_match(file_name))
             {
-                if let Some(locale) = self.extract_locale_from_path(path) {
-                    self.locale_files
-                        .entry(locale.clone())
-                        .or_default()
-                        .insert(path.to_path_buf());
-                    self.load_translation_file(path, &locale);
-                }
+                self.scan_file(path);
             }
+        }
+    }
+
+    fn scan_file(&self, path: &Path) {
+        if let Some(locale) = self.extract_locale_from_path(path) {
+            self.locale_files
+                .entry(locale.clone())
+                .or_default()
+                .insert(path.to_path_buf());
+            self.load_translation_file(path, &locale);
         }
     }
 
@@ -261,6 +306,25 @@ fn is_locale_code(s: &str) -> bool {
     common_locales.contains(&s)
 }
 
+fn has_glob_meta(path: &str) -> bool {
+    path.contains('*') || path.contains('?') || path.contains('[')
+}
+
+fn is_ignored_workspace_dir(path: &Path) -> bool {
+    if !path.is_dir() {
+        return false;
+    }
+
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            matches!(
+                name,
+                "node_modules" | ".git" | "target" | "dist" | "build" | ".nuxt" | ".output"
+            )
+        })
+}
+
 /// Extract locale from ARB filename patterns like "app_en", "messages_en_US", "intl_vi"
 fn extract_locale_from_arb_filename(file_stem: &str) -> Option<String> {
     // Common ARB file prefixes
@@ -293,4 +357,60 @@ fn extract_locale_from_arb_filename(file_stem: &str) -> Option<String> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    #[test]
+    fn scan_and_load_expands_glob_locale_directories() {
+        let root = test_workspace("glob-locale-directories");
+        let locale_dir = root.join("layers/foo/i18n/locales");
+        fs::create_dir_all(&locale_dir).expect("create locale dir");
+        fs::write(
+            locale_dir.join("en.json"),
+            r#"{"foo":{"greeting":"Hello from layer"}}"#,
+        )
+        .expect("write en locale");
+
+        let store = TranslationStore::new(root.clone());
+        store.scan_and_load(&["**/*/i18n/locales".to_string()]);
+
+        assert_eq!(
+            store.get_translation("foo.greeting", "en").as_deref(),
+            Some("Hello from layer")
+        );
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn scan_and_load_expands_glob_locale_files() {
+        let root = test_workspace("glob-locale-files");
+        let locale_dir = root.join("layers/foo/i18n/locales");
+        fs::create_dir_all(&locale_dir).expect("create locale dir");
+        fs::write(locale_dir.join("fr.json"), r#"{"hello":"Bonjour"}"#).expect("write fr locale");
+
+        let store = TranslationStore::new(root.clone());
+        store.scan_and_load(&["layers/*/i18n/locales/*.json".to_string()]);
+
+        assert_eq!(
+            store.get_translation("hello", "fr").as_deref(),
+            Some("Bonjour")
+        );
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    fn test_workspace(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("intl-lens-{name}-{nonce}"))
+    }
 }

--- a/crates/intl-lens/src/lib.rs
+++ b/crates/intl-lens/src/lib.rs
@@ -4,9 +4,12 @@ pub mod document;
 pub mod i18n;
 pub mod scanner;
 
+pub use audit::{
+    AuditReport, AuditResult, AuditSummary, FixSuggestion, KeyUsage, MissingTranslation,
+    PlaceholderIssue, PlaceholderIssueType, UnusedKey,
+};
 pub use config::{I18nConfig, KeyStyle};
-pub use i18n::store::{TranslationEntry, TranslationLocation, TranslationStore};
 pub use i18n::key_finder::{FoundKey, KeyFinder};
 pub use i18n::parser::TranslationParser;
-pub use audit::{AuditReport, AuditSummary, AuditResult, MissingTranslation, PlaceholderIssue, PlaceholderIssueType, UnusedKey, KeyUsage, FixSuggestion};
-pub use scanner::{CodeScanner, CodeKeyOccurrence, ScannedFile};
+pub use i18n::store::{TranslationEntry, TranslationLocation, TranslationStore};
+pub use scanner::{CodeKeyOccurrence, CodeScanner, ScannedFile};


### PR DESCRIPTION
## Summary

- add Nuxt layer locale auto-discovery for paths like `layers/*/i18n/locales`
- support glob-based locale paths such as `**/*/i18n/locales` when loading translations and matching watched files
- accept the i18n-ally `localesPaths` config alias

## Root cause

`localePaths` were previously resolved as literal workspace-relative paths. That meant nested Nuxt layer locale directories were missed unless they happened to match one of the built-in root-level paths.

Fixes #6.

## Verification

- `cargo test`
- `rustfmt --check crates/intl-lens/src/config.rs crates/intl-lens/src/i18n/store.rs crates/intl-lens/src/backend.rs`
- `git diff --check`
- checked `/Volumes/Avocado/code/sandbox/intl-lens-nuxt-repro/app.vue` with the local CLI and confirmed `hello` and `foo.greeting` are found with no missing keys
