### PR TITLE
fix: support i18next namespace dynamic keys

### DIFF
--- a/crates/intl-lens/src/audit.rs
+++ b/crates/intl-lens/src/audit.rs
@@ -326,7 +326,7 @@ mod tests {
 
         let config = I18nConfig::default();
         let store = TranslationStore::new(workspace.clone());
-        store.scan_and_load(&config.locale_paths);
+        store.scan_and_load_config(&config);
 
         let audit = AuditResult::new(workspace.clone(), config, store);
         let report = audit.generate_report();

--- a/crates/intl-lens/src/backend.rs
+++ b/crates/intl-lens/src/backend.rs
@@ -60,7 +60,7 @@ impl I18nBackend {
         *self.key_finder.write().await = key_finder;
 
         let store = TranslationStore::new(root.clone());
-        store.scan_and_load(&config.locale_paths);
+        store.scan_and_load_config(&config);
 
         let locales = store.get_locales();
         let keys = store.get_all_keys();
@@ -341,7 +341,7 @@ impl I18nBackend {
 
         let translations = store.get_all_translations(key);
         if translations.is_empty() {
-            return None;
+            return Self::get_prefix_hover_content(store, key, &config.source_locale);
         }
 
         let mut content = format!("### 🌍 `{}`\n\n", key);
@@ -380,6 +380,47 @@ impl I18nBackend {
                 content.push_str(&line);
             }
         }
+
+        Some(content)
+    }
+
+    fn get_prefix_hover_content(
+        store: &TranslationStore,
+        key: &str,
+        source_locale: &str,
+    ) -> Option<String> {
+        let prefixed = store.get_prefixed_translations(key);
+        if prefixed.is_empty() {
+            return None;
+        }
+
+        let mut content = format!("### 🌍 `{}`\n\n", key);
+        content.push_str("Object translation prefix\n\n");
+
+        if let Some(source_entries) = prefixed.get(source_locale) {
+            for (child_key, entry) in source_entries.iter().take(8) {
+                content.push_str(&format!("- `{}`: {}", child_key, entry.value));
+
+                if let Some(location) = store.get_translation_location(child_key, source_locale) {
+                    if let Ok(uri) = Url::from_file_path(&location.file_path) {
+                        let link = format!("{}#L{}", uri, location.line + 1);
+                        content.push_str(&format!(" ([↗]({} \"Go to Definition\"))", link));
+                    }
+                }
+
+                content.push('\n');
+            }
+
+            if source_entries.len() > 8 {
+                content.push_str(&format!("- … and {} more\n", source_entries.len() - 8));
+            }
+        }
+
+        let mut locales: Vec<String> = prefixed.keys().cloned().collect();
+        locales.sort();
+
+        content.push_str("\n---\n\n");
+        content.push_str(&format!("Available in: {}", locales.join(", ")));
 
         Some(content)
     }
@@ -578,14 +619,14 @@ impl I18nBackend {
 
     async fn reload_translations(&self) {
         let workspace_root = { self.workspace_root.read().await.clone() };
-        let locale_paths = { self.config.read().await.locale_paths.clone() };
+        let config = { self.config.read().await.clone() };
 
         let Some(root) = workspace_root.as_ref() else {
             return;
         };
 
         let store = TranslationStore::new(root.clone());
-        store.scan_and_load(&locale_paths);
+        store.scan_and_load_config(&config);
 
         let locales = store.get_locales();
         let keys = store.get_all_keys();

--- a/crates/intl-lens/src/cli.rs
+++ b/crates/intl-lens/src/cli.rs
@@ -114,7 +114,7 @@ async fn run_audit(
 
     pb.set_message("Scanning translation files...");
     let store = TranslationStore::new(workspace.to_path_buf());
-    store.scan_and_load(&config.locale_paths);
+    store.scan_and_load_config(&config);
 
     pb.set_message("Scanning codebase...");
     let mut result = AuditResult::new(workspace.to_path_buf(), config, store);
@@ -179,7 +179,7 @@ async fn run_check(
 
     // Load translations to check existence
     let store = TranslationStore::new(workspace.to_path_buf());
-    store.scan_and_load(&config.locale_paths);
+    store.scan_and_load_config(&config);
 
     let mut missing = Vec::new();
     let mut found = Vec::new();

--- a/crates/intl-lens/src/config.rs
+++ b/crates/intl-lens/src/config.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::i18n::namespace;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct I18nConfig {
@@ -18,6 +20,9 @@ pub struct I18nConfig {
 
     #[serde(default)]
     pub namespace_enabled: bool,
+
+    #[serde(default, alias = "defaultNS")]
+    pub default_namespace: Option<String>,
 
     #[serde(default = "default_function_patterns")]
     pub function_patterns: Vec<String>,
@@ -39,6 +44,7 @@ impl Default for I18nConfig {
             source_locale: default_source_locale(),
             key_style: default_key_style(),
             namespace_enabled: false,
+            default_namespace: None,
             function_patterns: default_function_patterns(),
         }
     }
@@ -57,18 +63,32 @@ impl I18nConfig {
                 let raw_config = serde_json::from_str::<Value>(&content).ok();
 
                 if let Ok(mut config) = serde_json::from_str::<I18nConfig>(&content) {
-                    let has_locale_paths = raw_config
-                        .as_ref()
-                        .and_then(|value| value.as_object())
-                        .is_some_and(|object| {
-                            object.contains_key("localePaths")
-                                || object.contains_key("locale_paths")
-                                || object.contains_key("localesPaths")
-                        });
+                    let raw_object = raw_config.as_ref().and_then(|value| value.as_object());
+                    let has_locale_paths = raw_object.is_some_and(|object| {
+                        object.contains_key("localePaths")
+                            || object.contains_key("locale_paths")
+                            || object.contains_key("localesPaths")
+                    });
+                    let has_source_locale = raw_object.is_some_and(|object| {
+                        object.contains_key("sourceLocale") || object.contains_key("source_locale")
+                    });
+                    let has_namespace_enabled = raw_object.is_some_and(|object| {
+                        object.contains_key("namespaceEnabled")
+                            || object.contains_key("namespace_enabled")
+                    });
+                    let has_default_namespace = raw_object.is_some_and(|object| {
+                        object.contains_key("defaultNamespace")
+                            || object.contains_key("default_namespace")
+                            || object.contains_key("defaultNS")
+                    });
 
-                    if !has_locale_paths {
-                        config.add_detected_locale_paths(root);
-                    }
+                    config.apply_detected_framework_config(
+                        root,
+                        !has_locale_paths,
+                        !has_source_locale,
+                        !has_namespace_enabled,
+                        !has_default_namespace,
+                    );
 
                     tracing::info!("Loaded config from {:?}", config_path);
                     return config;
@@ -78,23 +98,53 @@ impl I18nConfig {
 
         tracing::info!("Using default config");
         let mut config = Self::default();
-        config.add_detected_locale_paths(root);
+        config.apply_detected_framework_config(root, true, true, true, true);
         config
     }
 
-    fn add_detected_locale_paths(&mut self, root: &Path) {
-        let detected_paths = detect_framework_locale_paths(root);
-        if detected_paths.is_empty() {
-            return;
+    fn apply_detected_framework_config(
+        &mut self,
+        root: &Path,
+        merge_locale_paths: bool,
+        apply_source_locale: bool,
+        apply_namespace_enabled: bool,
+        apply_default_namespace: bool,
+    ) {
+        let detected = detect_framework_i18n(root);
+
+        if merge_locale_paths {
+            let mut existing: HashSet<String> = self.locale_paths.iter().cloned().collect();
+            for path in detected.locale_paths {
+                if existing.insert(path.clone()) {
+                    self.locale_paths.push(path);
+                }
+            }
         }
 
-        let mut existing: HashSet<String> = self.locale_paths.iter().cloned().collect();
-        for path in detected_paths {
-            if existing.insert(path.clone()) {
-                self.locale_paths.push(path);
+        if apply_source_locale {
+            if let Some(source_locale) = detected.source_locale {
+                self.source_locale = source_locale;
+            }
+        }
+
+        if apply_namespace_enabled && detected.namespace_enabled {
+            self.namespace_enabled = true;
+        }
+
+        if apply_default_namespace {
+            if let Some(default_namespace) = detected.default_namespace {
+                self.default_namespace = Some(default_namespace);
             }
         }
     }
+}
+
+#[derive(Debug, Default)]
+struct DetectedI18nConfig {
+    locale_paths: Vec<String>,
+    source_locale: Option<String>,
+    namespace_enabled: bool,
+    default_namespace: Option<String>,
 }
 
 fn default_locale_paths() -> Vec<String> {
@@ -103,6 +153,7 @@ fn default_locale_paths() -> Vec<String> {
         "i18n".to_string(),
         "translations".to_string(),
         "public/locales".to_string(),
+        "public/static/locales".to_string(),
         "src/locales".to_string(),
         "src/i18n".to_string(),
     ]
@@ -157,6 +208,24 @@ fn default_function_patterns() -> Vec<String> {
         r#"['"]([^'"]+)['"]\s*\.trParams\("#.to_string(),
         r#"['"]([^'"]+)['"]\s*\.trPlural\("#.to_string(),
     ]
+}
+
+fn detect_framework_i18n(root: &Path) -> DetectedI18nConfig {
+    let mut detected = DetectedI18nConfig::default();
+
+    if let Some(namespace_project) = namespace::detect_namespace_project(root) {
+        detected.locale_paths.extend(namespace_project.locale_paths);
+        detected.source_locale = namespace_project.source_locale;
+        detected.namespace_enabled = true;
+        detected.default_namespace = namespace_project.default_namespace;
+    }
+
+    detected
+        .locale_paths
+        .extend(detect_framework_locale_paths(root));
+    detected.locale_paths.sort();
+    detected.locale_paths.dedup();
+    detected
 }
 
 fn detect_framework_locale_paths(root: &Path) -> Vec<String> {
@@ -383,6 +452,39 @@ mod tests {
             config.locale_paths,
             vec!["src/lang".to_string(), "**/*/i18n/locales".to_string()]
         );
+    }
+
+    #[test]
+    fn detects_next_i18next_config() {
+        let root = test_workspace("next-i18next-detection");
+        fs::create_dir_all(root.join("public/static/locales/en")).expect("create locales");
+        fs::write(
+            root.join("next-i18next.config.js"),
+            r#"
+            const path = require('path')
+
+            module.exports = {
+              i18n: {
+                defaultLocale: 'en',
+                locales: ['ja', 'en', 'zh', 'zh-CN'],
+              },
+              localePath: path.resolve('./public/static/locales'),
+              defaultNS: 'common',
+            }
+            "#,
+        )
+        .expect("write next-i18next config");
+
+        let config = I18nConfig::load_from_workspace(&root);
+
+        assert!(config.namespace_enabled);
+        assert_eq!(config.source_locale, "en");
+        assert_eq!(config.default_namespace.as_deref(), Some("common"));
+        assert!(config
+            .locale_paths
+            .contains(&"public/static/locales".to_string()));
+
+        fs::remove_dir_all(root).ok();
     }
 
     fn test_workspace(name: &str) -> std::path::PathBuf {

--- a/crates/intl-lens/src/i18n/key_finder.rs
+++ b/crates/intl-lens/src/i18n/key_finder.rs
@@ -1,5 +1,7 @@
 use regex::Regex;
 
+use super::namespace;
+
 #[derive(Debug, Clone)]
 pub struct FoundKey {
     pub key: String,
@@ -25,31 +27,107 @@ impl KeyFinder {
 
     pub fn find_keys(&self, content: &str) -> Vec<FoundKey> {
         let mut found_keys = Vec::new();
+        let namespace_context = namespace::infer_namespace_context(content);
 
         for pattern in &self.patterns {
             for cap in pattern.captures_iter(content) {
                 if let Some(key_match) = cap.get(1) {
-                    let key = key_match.as_str().to_string();
-                    let start_offset = key_match.start();
-                    let end_offset = key_match.end();
-
-                    let (line, start_char, end_char) =
-                        Self::offset_to_position(content, start_offset, end_offset);
-
-                    found_keys.push(FoundKey {
-                        key,
-                        start_offset,
-                        line,
-                        start_char,
-                        end_char,
-                    });
+                    let raw_key = key_match.as_str();
+                    self.push_found_key(
+                        content,
+                        &namespace_context,
+                        raw_key,
+                        key_match,
+                        &mut found_keys,
+                    );
                 }
             }
         }
 
+        self.find_dynamic_template_prefixes(content, &namespace_context, &mut found_keys);
+
         found_keys.sort_by_key(|k| k.start_offset);
         found_keys.dedup_by(|a, b| a.start_offset == b.start_offset);
         found_keys
+    }
+
+    fn push_found_key(
+        &self,
+        content: &str,
+        namespace_context: &namespace::NamespaceContext,
+        raw_key: &str,
+        key_match: regex::Match<'_>,
+        found_keys: &mut Vec<FoundKey>,
+    ) {
+        self.push_found_key_with_range(
+            content,
+            namespace_context,
+            raw_key,
+            key_match.start(),
+            key_match.end(),
+            found_keys,
+        );
+    }
+
+    fn push_found_key_with_range(
+        &self,
+        content: &str,
+        namespace_context: &namespace::NamespaceContext,
+        raw_key: &str,
+        start_offset: usize,
+        end_offset: usize,
+        found_keys: &mut Vec<FoundKey>,
+    ) {
+        if raw_key.is_empty() {
+            return;
+        }
+
+        let key = namespace::apply_namespace_context(raw_key, namespace_context);
+
+        let (line, start_char, end_char) =
+            Self::offset_to_position(content, start_offset, end_offset);
+
+        found_keys.push(FoundKey {
+            key,
+            start_offset,
+            line,
+            start_char,
+            end_char,
+        });
+    }
+
+    fn find_dynamic_template_prefixes(
+        &self,
+        content: &str,
+        namespace_context: &namespace::NamespaceContext,
+        found_keys: &mut Vec<FoundKey>,
+    ) {
+        let Ok(pattern) =
+            Regex::new(r#"(?:^|[^\w.])(?:t|\$t|\$tc|\$te|i18n\.t)\s*\(\s*`([^`$]+?)\s*\$\{"#)
+        else {
+            return;
+        };
+
+        for cap in pattern.captures_iter(content) {
+            let Some(key_match) = cap.get(1) else {
+                continue;
+            };
+
+            let raw_key = key_match.as_str().trim_end_matches('.');
+            let end_offset = content[key_match.start()..]
+                .find('`')
+                .map(|relative| key_match.start() + relative)
+                .unwrap_or_else(|| key_match.end());
+
+            self.push_found_key_with_range(
+                content,
+                namespace_context,
+                raw_key,
+                key_match.start(),
+                end_offset,
+                found_keys,
+            );
+        }
     }
 
     pub fn find_key_at_position(
@@ -183,6 +261,86 @@ mod tests {
 
         let not_found = finder.find_key_at_position(content, 0, 0);
         assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_applies_single_use_translation_namespace() {
+        let finder = KeyFinder::default();
+        let content = r#"
+            const { t } = useTranslation('common');
+            const label = t('buttons.save');
+        "#;
+
+        let keys = finder.find_keys(content);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].key, "common.buttons.save");
+    }
+
+    #[test]
+    fn test_applies_first_use_translation_array_namespace() {
+        let finder = KeyFinder::default();
+        let content = r#"
+            const { t } = useTranslation(['member', 'common']);
+            const label = t('memberLabel.color');
+        "#;
+
+        let keys = finder.find_keys(content);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].key, "member.memberLabel.color");
+    }
+
+    #[test]
+    fn test_keeps_explicit_colon_namespace() {
+        let finder = KeyFinder::default();
+        let content = r#"
+            const { t } = useTranslation('common');
+            const label = t('common:buttons.save');
+        "#;
+
+        let keys = finder.find_keys(content);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].key, "common:buttons.save");
+    }
+
+    #[test]
+    fn test_find_dynamic_template_prefix() {
+        let finder = KeyFinder::default();
+        let content = r#"
+            const options = Object.keys(t('status', { returnObjects: true })).map(key => {
+                return t(`status.${key}`);
+            });
+        "#;
+
+        let keys = finder.find_keys(content);
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys[0].key, "status");
+        assert_eq!(keys[1].key, "status");
+
+        let dynamic_key = &keys[1];
+        assert!(dynamic_key.end_char > dynamic_key.start_char + "status".len());
+        assert!(finder
+            .find_key_at_position(content, dynamic_key.line, dynamic_key.start_char)
+            .is_some());
+        assert!(finder
+            .find_key_at_position(
+                content,
+                dynamic_key.line,
+                dynamic_key.end_char.saturating_sub(1)
+            )
+            .is_some());
+    }
+
+    #[test]
+    fn test_does_not_double_prefix_dot_namespace() {
+        let finder = KeyFinder::default();
+        let content = r#"
+            const { t } = useTranslation('common');
+            const label = t('common.buttons.save');
+        "#;
+
+        let keys = finder.find_keys(content);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].key, "common.buttons.save");
     }
 
     #[test]

--- a/crates/intl-lens/src/i18n/mod.rs
+++ b/crates/intl-lens/src/i18n/mod.rs
@@ -1,4 +1,5 @@
 pub mod key_finder;
+pub mod namespace;
 pub mod parser;
 pub mod store;
 

--- a/crates/intl-lens/src/i18n/namespace.rs
+++ b/crates/intl-lens/src/i18n/namespace.rs
@@ -1,0 +1,336 @@
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DetectedNamespaceProject {
+    pub locale_paths: Vec<String>,
+    pub source_locale: Option<String>,
+    pub default_namespace: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NamespaceContext {
+    pub namespaces: Vec<String>,
+}
+
+/// Detect common namespace-based i18n project configuration.
+///
+/// This intentionally returns a generic namespace project shape instead of leaking
+/// framework details to callers. More detectors can be added here without changing
+/// the LSP, store, scanner, CLI, or MCP layers.
+pub fn detect_namespace_project(root: &Path) -> Option<DetectedNamespaceProject> {
+    detect_next_i18next_project(root).or_else(|| detect_i18next_locale_tree(root))
+}
+
+/// Return the namespace prefix for a translation file.
+///
+/// File-based namespaces are common across i18next-style projects:
+/// `locales/en/common.json` -> `common.*`.
+/// PHP keeps its historical namespace behavior for Laravel language files.
+pub fn file_namespace_prefix<'a>(
+    extension: &str,
+    file_stem: &'a str,
+    namespace_enabled: bool,
+    is_locale_code: impl Fn(&str) -> bool,
+) -> Option<&'a str> {
+    if file_stem.is_empty() || is_locale_code(file_stem) {
+        return None;
+    }
+
+    if extension == "php" {
+        return Some(file_stem);
+    }
+
+    if namespace_enabled && matches!(extension, "json" | "yaml" | "yml") {
+        return Some(file_stem);
+    }
+
+    None
+}
+
+pub fn apply_file_namespace(key: String, namespace: Option<&str>) -> String {
+    match namespace {
+        Some(namespace) if key.starts_with(&format!("{}.", namespace)) => key,
+        Some(namespace) => format!("{}.{}", namespace, key),
+        None => key,
+    }
+}
+
+pub fn key_lookup_variants(key: &str) -> Vec<String> {
+    let mut variants = vec![key.to_string()];
+
+    if let Some((namespace, rest)) = key.split_once(':') {
+        if !namespace.is_empty() && !rest.is_empty() {
+            variants.push(format!("{}.{}", namespace, rest));
+        }
+    }
+
+    variants
+}
+
+pub fn infer_namespace_context(content: &str) -> NamespaceContext {
+    let mut namespaces = Vec::new();
+
+    if let Ok(single_namespace) = Regex::new(r#"useTranslation\s*\(\s*[\"']([A-Za-z0-9_-]+)[\"']"#)
+    {
+        for cap in single_namespace.captures_iter(content) {
+            if let Some(namespace) = cap.get(1) {
+                push_unique_namespace(&mut namespaces, namespace.as_str());
+            }
+        }
+    }
+
+    if let Ok(array_namespace) = Regex::new(r#"useTranslation\s*\(\s*\[([^\]]+)\]"#) {
+        for cap in array_namespace.captures_iter(content) {
+            let Some(items) = cap.get(1) else {
+                continue;
+            };
+
+            for namespace in parse_namespace_list(items.as_str()) {
+                push_unique_namespace(&mut namespaces, &namespace);
+            }
+        }
+    }
+
+    NamespaceContext { namespaces }
+}
+
+pub fn apply_namespace_context(raw_key: &str, context: &NamespaceContext) -> String {
+    if context.namespaces.is_empty() || raw_key.contains(':') {
+        return raw_key.to_string();
+    }
+
+    if context
+        .namespaces
+        .iter()
+        .any(|namespace| raw_key.starts_with(&format!("{}.", namespace)))
+    {
+        return raw_key.to_string();
+    }
+
+    format!("{}.{}", context.namespaces[0], raw_key)
+}
+
+fn detect_next_i18next_project(root: &Path) -> Option<DetectedNamespaceProject> {
+    let config_path = [
+        "next-i18next.config.js",
+        "next-i18next.config.cjs",
+        "next-i18next.config.mjs",
+        "next-i18next.config.ts",
+    ]
+    .iter()
+    .map(|file| root.join(file))
+    .find(|path| path.exists())?;
+
+    let content = std::fs::read_to_string(config_path).ok()?;
+    let mut detected = DetectedNamespaceProject::default();
+
+    if let Some(locale_path) = extract_js_string_property(&content, "localePath") {
+        detected
+            .locale_paths
+            .push(normalize_locale_path(root, &locale_path));
+    }
+
+    if detected.locale_paths.is_empty() {
+        detected.locale_paths.extend(existing_locale_roots(root));
+    }
+
+    detected.source_locale = extract_js_string_property(&content, "defaultLocale");
+    detected.default_namespace = extract_js_string_property(&content, "defaultNS")
+        .or_else(|| extract_js_string_property(&content, "defaultNamespace"));
+
+    Some(detected)
+}
+
+fn detect_i18next_locale_tree(root: &Path) -> Option<DetectedNamespaceProject> {
+    let locale_paths = existing_locale_roots(root);
+    if locale_paths
+        .iter()
+        .any(|path| looks_like_namespace_locale_root(root, path))
+    {
+        Some(DetectedNamespaceProject {
+            locale_paths,
+            source_locale: None,
+            default_namespace: None,
+        })
+    } else {
+        None
+    }
+}
+
+fn looks_like_namespace_locale_root(root: &Path, relative_path: &str) -> bool {
+    let base = root.join(relative_path);
+    let Ok(locale_entries) = std::fs::read_dir(base) else {
+        return false;
+    };
+
+    for locale_entry in locale_entries.filter_map(|entry| entry.ok()) {
+        let locale_path = locale_entry.path();
+        if !locale_path.is_dir() {
+            continue;
+        }
+
+        let Ok(files) = std::fs::read_dir(locale_path) else {
+            continue;
+        };
+
+        let namespace_file_count = files
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry.path().is_file()
+                    && entry
+                        .path()
+                        .extension()
+                        .and_then(|extension| extension.to_str())
+                        .is_some_and(|extension| matches!(extension, "json" | "yaml" | "yml"))
+            })
+            .take(2)
+            .count();
+
+        if namespace_file_count >= 2 {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn existing_locale_roots(root: &Path) -> Vec<String> {
+    ["public/locales", "public/static/locales", "locales"]
+        .into_iter()
+        .filter(|candidate| root.join(candidate).is_dir())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn extract_js_string_property(content: &str, property: &str) -> Option<String> {
+    let pattern = format!(
+        r#"(?s)\b{}\s*:\s*(?:path\.resolve\(\s*)?['\"]([^'\"]+)['\"]"#,
+        regex::escape(property)
+    );
+    let regex = Regex::new(&pattern).ok()?;
+    regex
+        .captures(content)
+        .and_then(|captures| captures.get(1))
+        .map(|matched| matched.as_str().trim().to_string())
+}
+
+fn normalize_locale_path(root: &Path, locale_path: &str) -> String {
+    let trimmed = locale_path
+        .trim()
+        .trim_start_matches("./")
+        .trim_end_matches(['/', '\\']);
+
+    let path = PathBuf::from(trimmed);
+    if path.is_absolute() {
+        path.strip_prefix(root)
+            .unwrap_or(path.as_path())
+            .to_string_lossy()
+            .replace('\\', "/")
+    } else {
+        trimmed.replace('\\', "/")
+    }
+}
+
+fn parse_namespace_list(input: &str) -> Vec<String> {
+    let Ok(namespace_item) = Regex::new(r#"[\"']([A-Za-z0-9_-]+)[\"']"#) else {
+        return Vec::new();
+    };
+
+    namespace_item
+        .captures_iter(input)
+        .filter_map(|captures| captures.get(1))
+        .map(|matched| matched.as_str().to_string())
+        .collect()
+}
+
+fn push_unique_namespace(namespaces: &mut Vec<String>, namespace: &str) {
+    if !namespace.is_empty() && !namespaces.iter().any(|existing| existing == namespace) {
+        namespaces.push(namespace.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    #[test]
+    fn key_lookup_variants_supports_i18next_colon_separator() {
+        assert_eq!(
+            key_lookup_variants("common:buttons.save"),
+            vec![
+                "common:buttons.save".to_string(),
+                "common.buttons.save".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn apply_file_namespace_does_not_duplicate_existing_root() {
+        assert_eq!(
+            apply_file_namespace("signin.description".to_string(), Some("signin")),
+            "signin.description"
+        );
+        assert_eq!(
+            apply_file_namespace("buttons.save".to_string(), Some("common")),
+            "common.buttons.save"
+        );
+    }
+
+    #[test]
+    fn infers_use_translation_namespaces() {
+        let context = infer_namespace_context(
+            r#"
+            const { t } = useTranslation('common')
+            const { t: memberT } = useTranslation(['member', 'common'])
+            "#,
+        );
+
+        assert_eq!(context.namespaces, vec!["common", "member"]);
+        assert_eq!(
+            apply_namespace_context("buttons.save", &context),
+            "common.buttons.save"
+        );
+        assert_eq!(
+            apply_namespace_context("common:buttons.save", &context),
+            "common:buttons.save"
+        );
+    }
+
+    #[test]
+    fn detects_next_i18next_project_config() {
+        let root = test_workspace("next-i18next-project");
+        fs::create_dir_all(root.join("public/static/locales/en")).expect("create locales");
+        fs::write(
+            root.join("next-i18next.config.js"),
+            r#"
+            const path = require('path')
+            module.exports = {
+              i18n: { defaultLocale: 'en', locales: ['en', 'ja'] },
+              localePath: path.resolve('./public/static/locales'),
+              defaultNS: 'common',
+            }
+            "#,
+        )
+        .expect("write config");
+
+        let detected = detect_namespace_project(&root).expect("detect namespace project");
+        assert_eq!(detected.locale_paths, vec!["public/static/locales"]);
+        assert_eq!(detected.source_locale.as_deref(), Some("en"));
+        assert_eq!(detected.default_namespace.as_deref(), Some("common"));
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    fn test_workspace(name: &str) -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("intl-lens-namespace-{name}-{nonce}"))
+    }
+}

--- a/crates/intl-lens/src/i18n/store.rs
+++ b/crates/intl-lens/src/i18n/store.rs
@@ -6,6 +6,9 @@ use globset::Glob;
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
+use crate::config::I18nConfig;
+use crate::i18n::namespace;
+
 use super::parser::TranslationParser;
 
 #[derive(Debug, Clone)]
@@ -36,6 +39,14 @@ impl TranslationStore {
     }
 
     pub fn scan_and_load(&self, locale_paths: &[String]) {
+        self.scan_and_load_with_options(locale_paths, false);
+    }
+
+    pub fn scan_and_load_config(&self, config: &I18nConfig) {
+        self.scan_and_load_with_options(&config.locale_paths, config.namespace_enabled);
+    }
+
+    fn scan_and_load_with_options(&self, locale_paths: &[String], namespace_enabled: bool) {
         for locale_path in locale_paths {
             let trimmed = locale_path.trim_end_matches(['/', '\\']);
             if trimmed.is_empty() {
@@ -43,20 +54,20 @@ impl TranslationStore {
             }
 
             if has_glob_meta(trimmed) {
-                self.scan_glob_path(trimmed);
+                self.scan_glob_path(trimmed, namespace_enabled);
                 continue;
             }
 
             let full_path = self.workspace_root.join(trimmed);
             if full_path.is_file() {
-                self.scan_file(&full_path);
+                self.scan_file(&full_path, namespace_enabled);
             } else if full_path.exists() {
-                self.scan_directory(&full_path);
+                self.scan_directory(&full_path, namespace_enabled);
             }
         }
     }
 
-    fn scan_glob_path(&self, locale_path: &str) {
+    fn scan_glob_path(&self, locale_path: &str, namespace_enabled: bool) {
         let Ok(glob) = Glob::new(locale_path) else {
             tracing::warn!("Invalid locale path glob: {}", locale_path);
             return;
@@ -78,14 +89,14 @@ impl TranslationStore {
             }
 
             if path.is_dir() {
-                self.scan_directory(path);
+                self.scan_directory(path, namespace_enabled);
             } else if path.is_file() {
-                self.scan_file(path);
+                self.scan_file(path, namespace_enabled);
             }
         }
     }
 
-    fn scan_directory(&self, dir: &Path) {
+    fn scan_directory(&self, dir: &Path, namespace_enabled: bool) {
         let json_glob = Glob::new("*.json").unwrap().compile_matcher();
         let yaml_glob = Glob::new("*.{yaml,yml}").unwrap().compile_matcher();
         let php_glob = Glob::new("*.php").unwrap().compile_matcher();
@@ -105,18 +116,18 @@ impl TranslationStore {
                     || php_glob.is_match(file_name)
                     || arb_glob.is_match(file_name))
             {
-                self.scan_file(path);
+                self.scan_file(path, namespace_enabled);
             }
         }
     }
 
-    fn scan_file(&self, path: &Path) {
+    fn scan_file(&self, path: &Path, namespace_enabled: bool) {
         if let Some(locale) = self.extract_locale_from_path(path) {
             self.locale_files
                 .entry(locale.clone())
                 .or_default()
                 .insert(path.to_path_buf());
-            self.load_translation_file(path, &locale);
+            self.load_translation_file(path, &locale, namespace_enabled);
         }
     }
 
@@ -148,24 +159,21 @@ impl TranslationStore {
         None
     }
 
-    fn load_translation_file(&self, path: &Path, locale: &str) {
+    fn load_translation_file(&self, path: &Path, locale: &str, namespace_enabled: bool) {
         match TranslationParser::parse_file(path) {
             Ok(translations) => {
                 let mut locale_map = self.translations.entry(locale.to_string()).or_default();
                 let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
                 let file_stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-                let prefix =
-                    if extension == "php" && !file_stem.is_empty() && !is_locale_code(file_stem) {
-                        Some(file_stem)
-                    } else {
-                        None
-                    };
+                let prefix = namespace::file_namespace_prefix(
+                    extension,
+                    file_stem,
+                    namespace_enabled,
+                    is_locale_code,
+                );
 
                 for (key, value) in translations {
-                    let full_key = match prefix {
-                        Some(prefix) => format!("{}.{}", prefix, key),
-                        None => key,
-                    };
+                    let full_key = namespace::apply_file_namespace(key, prefix);
 
                     locale_map.insert(
                         full_key,
@@ -190,31 +198,74 @@ impl TranslationStore {
     }
 
     pub fn get_translation(&self, key: &str, locale: &str) -> Option<String> {
-        self.translations
-            .get(locale)
-            .and_then(|map| map.get(key).map(|e| e.value.clone()))
+        self.translations.get(locale).and_then(|map| {
+            namespace::key_lookup_variants(key)
+                .iter()
+                .find_map(|candidate| map.get(candidate).map(|e| e.value.clone()))
+        })
     }
 
     pub fn get_all_translations(&self, key: &str) -> HashMap<String, TranslationEntry> {
         let mut result = HashMap::new();
+        let candidates = namespace::key_lookup_variants(key);
         for entry in self.translations.iter() {
             let locale = entry.key();
-            if let Some(translation) = entry.value().get(key) {
+            if let Some(translation) = candidates
+                .iter()
+                .find_map(|candidate| entry.value().get(candidate))
+            {
                 result.insert(locale.clone(), translation.clone());
             }
         }
         result
     }
 
+    pub fn get_prefixed_translations(
+        &self,
+        key: &str,
+    ) -> HashMap<String, Vec<(String, TranslationEntry)>> {
+        let mut result = HashMap::new();
+        let prefixes: Vec<String> = namespace::key_lookup_variants(key)
+            .into_iter()
+            .map(|candidate| format!("{}.", candidate))
+            .collect();
+
+        for entry in self.translations.iter() {
+            let mut matches: Vec<(String, TranslationEntry)> = entry
+                .value()
+                .iter()
+                .filter(|(existing_key, _)| {
+                    prefixes
+                        .iter()
+                        .any(|prefix| existing_key.starts_with(prefix))
+                })
+                .map(|(key, translation)| (key.clone(), translation.clone()))
+                .collect();
+
+            matches.sort_by(|a, b| a.0.cmp(&b.0));
+
+            if !matches.is_empty() {
+                result.insert(entry.key().clone(), matches);
+            }
+        }
+
+        result
+    }
+
     pub fn get_translation_location(&self, key: &str, locale: &str) -> Option<TranslationLocation> {
         self.translations.get(locale).and_then(|map| {
-            map.get(key).map(|e| {
-                let line = Self::find_key_line_in_file(&e.file_path, key).unwrap_or(0);
-                TranslationLocation {
-                    file_path: e.file_path.clone(),
-                    line,
-                }
-            })
+            namespace::key_lookup_variants(key)
+                .iter()
+                .find_map(|candidate| {
+                    map.get(candidate).map(|e| {
+                        let line =
+                            Self::find_key_line_in_file(&e.file_path, candidate).unwrap_or(0);
+                        TranslationLocation {
+                            file_path: e.file_path.clone(),
+                            line,
+                        }
+                    })
+                })
         })
     }
 
@@ -255,9 +306,12 @@ impl TranslationStore {
     }
 
     pub fn key_exists(&self, key: &str) -> bool {
-        self.translations
-            .iter()
-            .any(|entry| entry.value().contains_key(key))
+        let candidates = namespace::key_lookup_variants(key);
+        self.translations.iter().any(|entry| {
+            candidates
+                .iter()
+                .any(|candidate| key_or_prefix_exists(entry.value(), candidate))
+        })
     }
 
     pub fn get_locale_file_paths(&self, locale: &str) -> Vec<PathBuf> {
@@ -277,11 +331,25 @@ impl TranslationStore {
             .filter(|locale| {
                 self.translations
                     .get(locale)
-                    .map(|m| !m.contains_key(key))
+                    .map(|m| {
+                        let candidates = namespace::key_lookup_variants(key);
+                        !candidates
+                            .iter()
+                            .any(|candidate| key_or_prefix_exists(&m, candidate))
+                    })
                     .unwrap_or(true)
             })
             .collect()
     }
+}
+
+fn key_or_prefix_exists(map: &HashMap<String, TranslationEntry>, key: &str) -> bool {
+    if map.contains_key(key) {
+        return true;
+    }
+
+    let prefix = format!("{}.", key);
+    map.keys().any(|existing| existing.starts_with(&prefix))
 }
 
 fn is_locale_code(s: &str) -> bool {
@@ -402,6 +470,96 @@ mod tests {
             store.get_translation("hello", "fr").as_deref(),
             Some("Bonjour")
         );
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn scan_and_load_config_prefixes_json_namespace_files() {
+        let root = test_workspace("namespace-json-files");
+        let locale_dir = root.join("public/static/locales/en");
+        fs::create_dir_all(&locale_dir).expect("create locale dir");
+        fs::write(
+            locale_dir.join("common.json"),
+            r#"{"buttons":{"save":"Save"}}"#,
+        )
+        .expect("write namespace locale");
+
+        let config = I18nConfig {
+            locale_paths: vec!["public/static/locales".to_string()],
+            namespace_enabled: true,
+            ..Default::default()
+        };
+        let store = TranslationStore::new(root.clone());
+        store.scan_and_load_config(&config);
+
+        assert_eq!(
+            store
+                .get_translation("common.buttons.save", "en")
+                .as_deref(),
+            Some("Save")
+        );
+        assert_eq!(
+            store
+                .get_translation("common:buttons.save", "en")
+                .as_deref(),
+            Some("Save")
+        );
+        assert!(store.key_exists("common.buttons"));
+        assert!(store.get_missing_locales("common.buttons").is_empty());
+
+        let prefixed = store.get_prefixed_translations("common.buttons");
+        assert_eq!(prefixed["en"].len(), 1);
+        assert_eq!(prefixed["en"][0].0, "common.buttons.save");
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn scan_and_load_config_does_not_duplicate_existing_namespace_root() {
+        let root = test_workspace("namespace-existing-root");
+        let locale_dir = root.join("public/static/locales/en");
+        fs::create_dir_all(&locale_dir).expect("create locale dir");
+        fs::write(
+            locale_dir.join("signin.json"),
+            r#"{"signin":{"description":"Welcome"}}"#,
+        )
+        .expect("write namespace locale");
+
+        let config = I18nConfig {
+            locale_paths: vec!["public/static/locales".to_string()],
+            namespace_enabled: true,
+            ..Default::default()
+        };
+        let store = TranslationStore::new(root.clone());
+        store.scan_and_load_config(&config);
+
+        assert_eq!(
+            store.get_translation("signin.description", "en").as_deref(),
+            Some("Welcome")
+        );
+        assert!(store
+            .get_translation("signin.signin.description", "en")
+            .is_none());
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn scan_and_load_keeps_json_namespace_disabled_behavior() {
+        let root = test_workspace("namespace-disabled-json-files");
+        let locale_dir = root.join("locales/en");
+        fs::create_dir_all(&locale_dir).expect("create locale dir");
+        fs::write(locale_dir.join("common.json"), r#"{"hello":"Hello"}"#).expect("write locale");
+
+        let store = TranslationStore::new(root.clone());
+        store.scan_and_load(&["locales".to_string()]);
+
+        assert_eq!(
+            store.get_translation("hello", "en").as_deref(),
+            Some("Hello")
+        );
+        assert!(store.get_translation("common.hello", "en").is_none());
 
         fs::remove_dir_all(root).ok();
     }

--- a/crates/intl-lens/src/mcp.rs
+++ b/crates/intl-lens/src/mcp.rs
@@ -435,7 +435,7 @@ impl McpServer {
     fn load_store(&self, workspace: &Path) -> (I18nConfig, TranslationStore) {
         let config = I18nConfig::load_from_workspace(workspace);
         let store = TranslationStore::new(workspace.to_path_buf());
-        store.scan_and_load(&config.locale_paths);
+        store.scan_and_load_config(&config);
         (config, store)
     }
 }


### PR DESCRIPTION
# Description

Add generic i18next namespace support and improve dynamic translation key handling for Zed/LSP users. This fixes missing diagnostics and hover behavior for namespace-based projects such as `next-i18next`, including patterns like `common:message.update.success`, `useTranslation('common')`, and dynamic object access such as `t(`status.${key}`)`.

**Root cause:**

The scanner only extracted literal translation keys and the store only treated exact leaf keys as valid. Namespace-based locale files like `locales/en/common.json` were not consistently loaded with their namespace prefix, `ns:key` lookups were not normalized to dot-path keys, and object-return patterns such as `t('status', { returnObjects: true })` had no exact `status` leaf key to hover or validate against.

**Fix:**

- Add a shared namespace helper module for detecting i18next-style locale trees and applying namespace prefixes consistently.
- Normalize colon namespace lookups such as `common:buttons.save` to the loaded `common.buttons.save` key shape.
- Infer namespaces from `useTranslation(...)` calls and avoid double-prefixing already-qualified keys.
- Treat object prefixes as valid when leaf translations exist below them, so `returnObjects: true` usage does not report false missing keys.
- Extract static prefixes from dynamic template strings like `t(`status.${key}`)` and show hover summaries for matching child translations.

Epic/Task/Bug/Todo URL: N/A — user-reported Zed i18n plugin behavior.

# Type of change

- [x] Bug fix
- [x] Feature / behavior improvement
- [ ] Documentation only
- [ ] Refactor only

# Code protection

No feature flag or environment flag. The changes are scoped to namespace detection/loading and key lookup/extraction behavior.

# Self Test Checklist

- [x] Ran `cargo fmt`
- [x] Ran `cargo test -p intl-lens`
- [x] Built release binary with `cargo build --release -p intl-lens --bin intl-lens`
