### PR TITLE
feat: add keySeparator config option

### DIFF
--- a/crates/intl-lens/src/audit.rs
+++ b/crates/intl-lens/src/audit.rs
@@ -325,7 +325,7 @@ mod tests {
             .expect("write vi translations");
 
         let config = I18nConfig::default();
-        let store = TranslationStore::new(workspace.clone());
+        let store = TranslationStore::new(workspace.clone(), config.separator().to_string());
         store.scan_and_load(&config.locale_paths);
 
         let audit = AuditResult::new(workspace.clone(), config, store);

--- a/crates/intl-lens/src/backend.rs
+++ b/crates/intl-lens/src/backend.rs
@@ -59,7 +59,7 @@ impl I18nBackend {
         let key_finder = KeyFinder::new(&config.function_patterns);
         *self.key_finder.write().await = key_finder;
 
-        let store = TranslationStore::new(root.clone());
+        let store = TranslationStore::new(root.clone(), config.separator().to_string());
         store.scan_and_load(&config.locale_paths);
 
         let locales = store.get_locales();
@@ -578,13 +578,15 @@ impl I18nBackend {
 
     async fn reload_translations(&self) {
         let workspace_root = { self.workspace_root.read().await.clone() };
-        let locale_paths = { self.config.read().await.locale_paths.clone() };
+        let config = { self.config.read().await.clone() };
+        let locale_paths = config.locale_paths.clone();
+        let separator = config.separator().to_string();
 
         let Some(root) = workspace_root.as_ref() else {
             return;
         };
 
-        let store = TranslationStore::new(root.clone());
+        let store = TranslationStore::new(root.clone(), separator);
         store.scan_and_load(&locale_paths);
 
         let locales = store.get_locales();
@@ -1051,6 +1053,10 @@ impl LanguageServer for I18nBackend {
             raw_value
         );
 
+        let config = self.config.read().await;
+        let separator = config.separator().to_string();
+        drop(config);
+
         let translation_store = self.translation_store.read().await;
         let Some(store) = translation_store.as_ref() else {
             tracing::warn!("createRawTranslationKey: no translation store");
@@ -1085,7 +1091,7 @@ impl LanguageServer for I18nBackend {
                 }
             };
 
-            let result = Self::insert_key_into_json(&file_content, &key, &raw_value);
+            let result = Self::insert_key_into_json(&file_content, &key, &raw_value, &separator);
             let Some((new_content, _, _)) = result else {
                 tracing::warn!("Failed to insert key into {:?}", file_path);
                 continue;
@@ -1198,11 +1204,11 @@ impl I18nBackend {
     /// Insert a (possibly nested) key into a JSON string with the given value,
     /// using text-based insertion to preserve existing formatting and key order.
     /// Returns `(new_content, cursor_line, cursor_character)`.
-    fn insert_key_into_json(content: &str, key: &str, value: &str) -> Option<(String, u32, u32)> {
+    fn insert_key_into_json(content: &str, key: &str, value: &str, separator: &str) -> Option<(String, u32, u32)> {
         // Validate JSON and detect style
         let root: Value = serde_json::from_str(content).ok()?;
         let root_obj = root.as_object()?;
-        let parts: Vec<&str> = key.split('.').collect();
+        let parts: Vec<&str> = key.split(separator).collect();
         let indent = Self::detect_indent_unit(content);
 
         // Flat style: all top-level values are non-objects (i.e. no nesting)
@@ -1457,7 +1463,7 @@ mod tests {
     #[test]
     fn test_insert_flat_key_into_flat_json() {
         let content = "{\n  \"hello\": \"world\",\n  \"foo\": \"bar\"\n}\n";
-        let result = I18nBackend::insert_key_into_json(content, "new.key", "_new.key_");
+        let result = I18nBackend::insert_key_into_json(content, "new.key", "_new.key_", ".");
         assert!(result.is_some());
         let (new_content, cursor_line, _cursor_col) = result.unwrap();
         assert!(new_content.contains("\"new.key\": \"_new.key_\""));
@@ -1469,7 +1475,7 @@ mod tests {
     fn test_insert_nested_key_into_existing_parent() {
         let content = "{\n  \"common\": {\n    \"hello\": \"world\"\n  }\n}\n";
         let result =
-            I18nBackend::insert_key_into_json(content, "common.goodbye", "_common.goodbye_");
+            I18nBackend::insert_key_into_json(content, "common.goodbye", "_common.goodbye_", ".");
         assert!(result.is_some());
         let (new_content, cursor_line, _cursor_col) = result.unwrap();
         assert!(new_content.contains("\"goodbye\": \"_common.goodbye_\""));
@@ -1481,7 +1487,7 @@ mod tests {
     fn test_insert_creates_intermediate_objects() {
         let content = "{\n  \"common\": {\n    \"hello\": \"world\"\n  }\n}\n";
         let result =
-            I18nBackend::insert_key_into_json(content, "pages.home.title", "_pages.home.title_");
+            I18nBackend::insert_key_into_json(content, "pages.home.title", "_pages.home.title_", ".");
         assert!(result.is_some());
         let (new_content, cursor_line, _cursor_col) = result.unwrap();
         assert!(new_content.contains("\"pages\": {"));
@@ -1494,7 +1500,7 @@ mod tests {
     #[test]
     fn test_insert_single_segment_key() {
         let content = "{\n  \"hello\": \"world\"\n}\n";
-        let result = I18nBackend::insert_key_into_json(content, "goodbye", "_goodbye_");
+        let result = I18nBackend::insert_key_into_json(content, "goodbye", "_goodbye_", ".");
         assert!(result.is_some());
         let (new_content, _, _) = result.unwrap();
         assert!(new_content.contains("\"goodbye\": \"_goodbye_\""));
@@ -1504,7 +1510,7 @@ mod tests {
     #[test]
     fn test_insert_preserves_existing_content() {
         let content = "{\n  \"hello\": \"world\",\n  \"foo\": \"bar\"\n}\n";
-        let result = I18nBackend::insert_key_into_json(content, "baz", "_baz_");
+        let result = I18nBackend::insert_key_into_json(content, "baz", "_baz_", ".");
         assert!(result.is_some());
         let (new_content, _, _) = result.unwrap();
         assert!(new_content.contains("\"hello\": \"world\""));
@@ -1546,7 +1552,7 @@ mod tests {
     #[test]
     fn test_cursor_position_points_inside_value_quotes() {
         let content = "{\n  \"hello\": \"world\"\n}\n";
-        let result = I18nBackend::insert_key_into_json(content, "test", "_test_");
+        let result = I18nBackend::insert_key_into_json(content, "test", "_test_", ".");
         let (_new_content, cursor_line, cursor_col) = result.unwrap();
         let line = _new_content.lines().nth(cursor_line as usize).unwrap();
         let before_cursor = &line[..cursor_col as usize];
@@ -1561,7 +1567,7 @@ mod tests {
     fn test_insert_adds_trailing_comma_to_previous_entry() {
         // No trailing comma after "world"
         let content = "{\n  \"hello\": \"world\"\n}\n";
-        let result = I18nBackend::insert_key_into_json(content, "goodbye", "_goodbye_");
+        let result = I18nBackend::insert_key_into_json(content, "goodbye", "_goodbye_", ".");
         assert!(result.is_some());
         let (new_content, _, _) = result.unwrap();
         assert!(
@@ -1576,7 +1582,7 @@ mod tests {
         let content =
             "{\n  \"buttons\": {\n    \"save\": \"Save\"\n  },\n  \"labels\": {\n    \"name\": \"Name\"\n  }\n}\n";
         let result =
-            I18nBackend::insert_key_into_json(content, "buttons.cancel", "_buttons.cancel_");
+            I18nBackend::insert_key_into_json(content, "buttons.cancel", "_buttons.cancel_", ".");
         assert!(result.is_some());
         let (new_content, cursor_line, _) = result.unwrap();
         assert!(new_content.contains("\"cancel\": \"_buttons.cancel_\""));
@@ -1607,7 +1613,7 @@ mod tests {
     fn test_insert_deeply_nested_into_flat_file_uses_dotted_key() {
         // When the file is flat-style (no nested objects), the key is inserted as a dotted string
         let content = "{\n  \"existing\": \"value\"\n}\n";
-        let result = I18nBackend::insert_key_into_json(content, "a.b.c.d", "_a.b.c.d_");
+        let result = I18nBackend::insert_key_into_json(content, "a.b.c.d", "_a.b.c.d_", ".");
         assert!(result.is_some());
         let (new_content, cursor_line, _) = result.unwrap();
         assert!(
@@ -1623,7 +1629,7 @@ mod tests {
     fn test_insert_deeply_nested_creates_all_parents() {
         // When the file already has nested objects, new keys should be nested too
         let content = "{\n  \"common\": {\n    \"hello\": \"world\"\n  }\n}\n";
-        let result = I18nBackend::insert_key_into_json(content, "a.b.c.d", "_a.b.c.d_");
+        let result = I18nBackend::insert_key_into_json(content, "a.b.c.d", "_a.b.c.d_", ".");
         assert!(result.is_some());
         let (new_content, cursor_line, _) = result.unwrap();
         assert!(new_content.contains("\"a\": {"));
@@ -1654,7 +1660,7 @@ mod tests {
     #[test]
     fn test_invalid_json_returns_none() {
         let content = "not valid json";
-        let result = I18nBackend::insert_key_into_json(content, "test", "_test_");
+        let result = I18nBackend::insert_key_into_json(content, "test", "_test_", ".");
         assert!(result.is_none());
     }
 }

--- a/crates/intl-lens/src/cli.rs
+++ b/crates/intl-lens/src/cli.rs
@@ -113,7 +113,7 @@ async fn run_audit(
     let config = I18nConfig::load_from_workspace(workspace);
 
     pb.set_message("Scanning translation files...");
-    let store = TranslationStore::new(workspace.to_path_buf());
+    let store = TranslationStore::new(workspace.to_path_buf(), config.separator().to_string());
     store.scan_and_load(&config.locale_paths);
 
     pb.set_message("Scanning codebase...");
@@ -178,7 +178,7 @@ async fn run_check(
     }
 
     // Load translations to check existence
-    let store = TranslationStore::new(workspace.to_path_buf());
+    let store = TranslationStore::new(workspace.to_path_buf(), config.separator().to_string());
     store.scan_and_load(&config.locale_paths);
 
     let mut missing = Vec::new();

--- a/crates/intl-lens/src/config.rs
+++ b/crates/intl-lens/src/config.rs
@@ -21,6 +21,9 @@ pub struct I18nConfig {
 
     #[serde(default = "default_function_patterns")]
     pub function_patterns: Vec<String>,
+
+    #[serde(default)]
+    pub key_separator: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
@@ -40,11 +43,16 @@ impl Default for I18nConfig {
             key_style: default_key_style(),
             namespace_enabled: false,
             function_patterns: default_function_patterns(),
+            key_separator: None,
         }
     }
 }
 
 impl I18nConfig {
+    pub fn separator(&self) -> &str {
+        self.key_separator.as_deref().unwrap_or(".")
+    }
+
     pub fn load_from_workspace(root: &Path) -> Self {
         let config_paths = [
             root.join(".i18n-ally.json"),

--- a/crates/intl-lens/src/i18n/parser.rs
+++ b/crates/intl-lens/src/i18n/parser.rs
@@ -8,15 +8,15 @@ use serde_yaml::Value as YamlValue;
 pub struct TranslationParser;
 
 impl TranslationParser {
-    pub fn parse_file(path: &Path) -> Result<HashMap<String, String>> {
+    pub fn parse_file(path: &Path, separator: &str) -> Result<HashMap<String, String>> {
         let content = std::fs::read_to_string(path)?;
         let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
         match extension {
-            "yaml" | "yml" => Self::parse_yaml(&content),
-            "php" => Self::parse_php(&content),
+            "yaml" | "yml" => Self::parse_yaml(&content, separator),
+            "php" => Self::parse_php(&content, separator),
             "arb" => Self::parse_arb(&content),
-            _ => Self::parse_json(&content),
+            _ => Self::parse_json(&content, separator),
         }
     }
 
@@ -43,38 +43,38 @@ impl TranslationParser {
         Ok(result)
     }
 
-    pub fn parse_php(content: &str) -> Result<HashMap<String, String>> {
+    pub fn parse_php(content: &str, separator: &str) -> Result<HashMap<String, String>> {
         let mut parser = PhpParser::new(content);
         let value = parser.parse_root_array()?;
         let mut result = HashMap::new();
-        flatten_php(&value, String::new(), &mut result);
+        flatten_php(&value, String::new(), &mut result, separator);
         Ok(result)
     }
 
-    pub fn parse_json(content: &str) -> Result<HashMap<String, String>> {
+    pub fn parse_json(content: &str, separator: &str) -> Result<HashMap<String, String>> {
         let value: JsonValue = serde_json::from_str(content)?;
         let mut result = HashMap::new();
-        Self::flatten_json(&value, String::new(), &mut result);
+        Self::flatten_json(&value, String::new(), &mut result, separator);
         Ok(result)
     }
 
-    pub fn parse_yaml(content: &str) -> Result<HashMap<String, String>> {
+    pub fn parse_yaml(content: &str, separator: &str) -> Result<HashMap<String, String>> {
         let value: YamlValue = serde_yaml::from_str(content)?;
         let mut result = HashMap::new();
-        Self::flatten_yaml(&value, String::new(), &mut result);
+        Self::flatten_yaml(&value, String::new(), &mut result, separator);
         Ok(result)
     }
 
-    fn flatten_json(value: &JsonValue, prefix: String, result: &mut HashMap<String, String>) {
+    fn flatten_json(value: &JsonValue, prefix: String, result: &mut HashMap<String, String>, separator: &str) {
         match value {
             JsonValue::Object(map) => {
                 for (key, val) in map {
                     let new_key = if prefix.is_empty() {
                         key.clone()
                     } else {
-                        format!("{}.{}", prefix, key)
+                        format!("{}{}{}", prefix, separator, key)
                     };
-                    Self::flatten_json(val, new_key, result);
+                    Self::flatten_json(val, new_key, result, separator);
                 }
             }
             JsonValue::String(s) => {
@@ -88,15 +88,15 @@ impl TranslationParser {
             }
             JsonValue::Array(arr) => {
                 for (i, val) in arr.iter().enumerate() {
-                    let new_key = format!("{}.{}", prefix, i);
-                    Self::flatten_json(val, new_key, result);
+                    let new_key = format!("{}{}{}", prefix, separator, i);
+                    Self::flatten_json(val, new_key, result, separator);
                 }
             }
             JsonValue::Null => {}
         }
     }
 
-    fn flatten_yaml(value: &YamlValue, prefix: String, result: &mut HashMap<String, String>) {
+    fn flatten_yaml(value: &YamlValue, prefix: String, result: &mut HashMap<String, String>, separator: &str) {
         match value {
             YamlValue::Mapping(map) => {
                 for (key, val) in map {
@@ -107,9 +107,9 @@ impl TranslationParser {
                     let new_key = if prefix.is_empty() {
                         key_str
                     } else {
-                        format!("{}.{}", prefix, key_str)
+                        format!("{}{}{}", prefix, separator, key_str)
                     };
-                    Self::flatten_yaml(val, new_key, result);
+                    Self::flatten_yaml(val, new_key, result, separator);
                 }
             }
             YamlValue::String(s) => {
@@ -123,8 +123,8 @@ impl TranslationParser {
             }
             YamlValue::Sequence(arr) => {
                 for (i, val) in arr.iter().enumerate() {
-                    let new_key = format!("{}.{}", prefix, i);
-                    Self::flatten_yaml(val, new_key, result);
+                    let new_key = format!("{}{}{}", prefix, separator, i);
+                    Self::flatten_yaml(val, new_key, result, separator);
                 }
             }
             YamlValue::Null | YamlValue::Tagged(_) => {}
@@ -474,7 +474,7 @@ fn value_to_key(value: &PhpValue) -> String {
     }
 }
 
-fn flatten_php(value: &PhpValue, prefix: String, result: &mut HashMap<String, String>) {
+fn flatten_php(value: &PhpValue, prefix: String, result: &mut HashMap<String, String>, separator: &str) {
     match value {
         PhpValue::String(value) => {
             if !prefix.is_empty() {
@@ -511,9 +511,9 @@ fn flatten_php(value: &PhpValue, prefix: String, result: &mut HashMap<String, St
                 let new_prefix = if prefix.is_empty() {
                     key
                 } else {
-                    format!("{}.{}", prefix, key)
+                    format!("{}{}{}", prefix, separator, key)
                 };
-                flatten_php(entry, new_prefix, result);
+                flatten_php(entry, new_prefix, result, separator);
             }
         }
     }
@@ -526,7 +526,7 @@ mod tests {
     #[test]
     fn test_parse_flat_json() {
         let json = r#"{"hello": "Hello", "world": "World"}"#;
-        let result = TranslationParser::parse_json(json).unwrap();
+        let result = TranslationParser::parse_json(json, ".").unwrap();
         assert_eq!(result.get("hello"), Some(&"Hello".to_string()));
         assert_eq!(result.get("world"), Some(&"World".to_string()));
     }
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn test_parse_nested_json() {
         let json = r#"{"common": {"hello": "Hello", "bye": "Goodbye"}}"#;
-        let result = TranslationParser::parse_json(json).unwrap();
+        let result = TranslationParser::parse_json(json, ".").unwrap();
         assert_eq!(result.get("common.hello"), Some(&"Hello".to_string()));
         assert_eq!(result.get("common.bye"), Some(&"Goodbye".to_string()));
     }
@@ -542,14 +542,22 @@ mod tests {
     #[test]
     fn test_parse_deeply_nested() {
         let json = r#"{"a": {"b": {"c": "deep"}}}"#;
-        let result = TranslationParser::parse_json(json).unwrap();
+        let result = TranslationParser::parse_json(json, ".").unwrap();
         assert_eq!(result.get("a.b.c"), Some(&"deep".to_string()));
+    }
+
+    #[test]
+    fn test_parse_nested_json_custom_separator() {
+        let json = r#"{"common": {"hello": "Hello", "bye": "Goodbye"}}"#;
+        let result = TranslationParser::parse_json(json, ":").unwrap();
+        assert_eq!(result.get("common:hello"), Some(&"Hello".to_string()));
+        assert_eq!(result.get("common:bye"), Some(&"Goodbye".to_string()));
     }
 
     #[test]
     fn test_parse_flat_yaml() {
         let yaml = "hello: Hello\nworld: World";
-        let result = TranslationParser::parse_yaml(yaml).unwrap();
+        let result = TranslationParser::parse_yaml(yaml, ".").unwrap();
         assert_eq!(result.get("hello"), Some(&"Hello".to_string()));
         assert_eq!(result.get("world"), Some(&"World".to_string()));
     }
@@ -557,7 +565,7 @@ mod tests {
     #[test]
     fn test_parse_nested_yaml() {
         let yaml = "common:\n  hello: Hello\n  bye: Goodbye";
-        let result = TranslationParser::parse_yaml(yaml).unwrap();
+        let result = TranslationParser::parse_yaml(yaml, ".").unwrap();
         assert_eq!(result.get("common.hello"), Some(&"Hello".to_string()));
         assert_eq!(result.get("common.bye"), Some(&"Goodbye".to_string()));
     }
@@ -565,7 +573,7 @@ mod tests {
     #[test]
     fn test_parse_flat_php() {
         let php = r#"<?php return ['hello' => 'Hello', "world" => "World"];"#;
-        let result = TranslationParser::parse_php(php).unwrap();
+        let result = TranslationParser::parse_php(php, ".").unwrap();
         assert_eq!(result.get("hello"), Some(&"Hello".to_string()));
         assert_eq!(result.get("world"), Some(&"World".to_string()));
     }
@@ -579,7 +587,7 @@ mod tests {
                 'bye' => "Goodbye",
             ],
         ];"#;
-        let result = TranslationParser::parse_php(php).unwrap();
+        let result = TranslationParser::parse_php(php, ".").unwrap();
         assert_eq!(result.get("common.hello"), Some(&"Hello".to_string()));
         assert_eq!(result.get("common.bye"), Some(&"Goodbye".to_string()));
     }

--- a/crates/intl-lens/src/i18n/store.rs
+++ b/crates/intl-lens/src/i18n/store.rs
@@ -24,14 +24,16 @@ pub struct TranslationStore {
     translations: DashMap<String, HashMap<String, TranslationEntry>>,
     locale_files: DashMap<String, HashSet<PathBuf>>,
     workspace_root: PathBuf,
+    key_separator: String,
 }
 
 impl TranslationStore {
-    pub fn new(workspace_root: PathBuf) -> Self {
+    pub fn new(workspace_root: PathBuf, key_separator: String) -> Self {
         Self {
             translations: DashMap::new(),
             locale_files: DashMap::new(),
             workspace_root,
+            key_separator,
         }
     }
 
@@ -149,7 +151,7 @@ impl TranslationStore {
     }
 
     fn load_translation_file(&self, path: &Path, locale: &str) {
-        match TranslationParser::parse_file(path) {
+        match TranslationParser::parse_file(path, &self.key_separator) {
             Ok(translations) => {
                 let mut locale_map = self.translations.entry(locale.to_string()).or_default();
                 let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -163,7 +165,7 @@ impl TranslationStore {
 
                 for (key, value) in translations {
                     let full_key = match prefix {
-                        Some(prefix) => format!("{}.{}", prefix, key),
+                        Some(prefix) => format!("{}{}{}", prefix, self.key_separator, key),
                         None => key,
                     };
 
@@ -209,7 +211,7 @@ impl TranslationStore {
     pub fn get_translation_location(&self, key: &str, locale: &str) -> Option<TranslationLocation> {
         self.translations.get(locale).and_then(|map| {
             map.get(key).map(|e| {
-                let line = Self::find_key_line_in_file(&e.file_path, key).unwrap_or(0);
+                let line = Self::find_key_line_in_file(&e.file_path, key, &self.key_separator).unwrap_or(0);
                 TranslationLocation {
                     file_path: e.file_path.clone(),
                     line,
@@ -218,10 +220,10 @@ impl TranslationStore {
         })
     }
 
-    fn find_key_line_in_file(file_path: &Path, key: &str) -> Option<usize> {
+    fn find_key_line_in_file(file_path: &Path, key: &str, separator: &str) -> Option<usize> {
         let content = std::fs::read_to_string(file_path).ok()?;
 
-        let last_part = key.split('.').next_back().unwrap_or(key);
+        let last_part = key.rsplit(separator).next().unwrap_or(key);
         let search_patterns = [
             format!("\"{}\"", last_part),
             format!("'{}'", last_part),
@@ -377,7 +379,7 @@ mod tests {
         )
         .expect("write en locale");
 
-        let store = TranslationStore::new(root.clone());
+        let store = TranslationStore::new(root.clone(), ".".to_string());
         store.scan_and_load(&["**/*/i18n/locales".to_string()]);
 
         assert_eq!(
@@ -395,7 +397,7 @@ mod tests {
         fs::create_dir_all(&locale_dir).expect("create locale dir");
         fs::write(locale_dir.join("fr.json"), r#"{"hello":"Bonjour"}"#).expect("write fr locale");
 
-        let store = TranslationStore::new(root.clone());
+        let store = TranslationStore::new(root.clone(), ".".to_string());
         store.scan_and_load(&["layers/*/i18n/locales/*.json".to_string()]);
 
         assert_eq!(

--- a/crates/intl-lens/src/mcp.rs
+++ b/crates/intl-lens/src/mcp.rs
@@ -434,7 +434,7 @@ impl McpServer {
 
     fn load_store(&self, workspace: &Path) -> (I18nConfig, TranslationStore) {
         let config = I18nConfig::load_from_workspace(workspace);
-        let store = TranslationStore::new(workspace.to_path_buf());
+        let store = TranslationStore::new(workspace.to_path_buf(), config.separator().to_string());
         store.scan_and_load(&config.locale_paths);
         (config, store)
     }


### PR DESCRIPTION
Added an optional `keySeparator` field to the '.zed/i18n.json' config, allowing projects that use a non-default key separator to work correctly with intl-lens.

By default, intl-lens uses "." as the separator. 

Usage Example:
'
{
  "localePaths": ["public/translations"],
  "sourceLocale": "en",
  "keySeparator": ":"
}
'

This allows keys like 't("common:button.add")' to be resolved correctly instead of reporting "key not found"